### PR TITLE
Fix "npm install" issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,10 @@ The packaging consists of app, styles, and bootstrap.
 
 npm install
 
- - `npm run dep` Installs global dependencies.
- - `npm run build` Builds the project. Required when typescript is changed.
- - `npm run test` Runs node server and starts chrome in app mode with web security disabled.
+ - `npm install` Installs local dependencies.
+ - `npm run dep` Installs [global dependencies](https://docs.npmjs.com/getting-started/installing-npm-packages-globally) (allowing them to be used from commandline)
+ - `npm run build` Builds the project. *Required when typescript is changed.*
+ - `npm run test` Runs node server and starts chrome in app mode with web security disabled. Visit http://localhost:3000/
  - `npm run watch` Builds, runs, and watches for changes to build again.
  
 # Collaboration

--- a/package.json
+++ b/package.json
@@ -7,12 +7,12 @@
     "type": "git",
     "url": "https://github.com/DSpace-Labs/angular2-ui-prototype.git"
   },
-  "license": "Copyright (c) 2002-2013, DuraSpace",
+  "license": "BSD-3-Clause",
   "contributors": [
-	"Tim Donohue <tdonohue@duraspace.org>",
-	"Art Lowel <art@atmire.com>",
-	"Andrea Bollini <a.bollini@cineca.it>",
-	"James Creel <jcreel@library.tamu.edu>",
+    "Tim Donohue <tdonohue@duraspace.org>",
+    "Art Lowel <art@atmire.com>",
+    "Andrea Bollini <a.bollini@cineca.it>",
+    "James Creel <jcreel@library.tamu.edu>",
     "William Welling <wwelling@library.tamu.edu>"
   ],
   "scripts": {
@@ -32,7 +32,8 @@
     "express": "^4.13.4",
     "jquery": "^2.2.2",
     "preboot": "^2.0.5",
-    "rxjs": "5.0.0-beta.3"    
+    "rxjs": "5.0.0-beta.2",
+    "zone.js": "~0.6.6"
   },
   "devDependencies": {
     "bootstrap-loader": "^1.0.10",


### PR DESCRIPTION
This PR fixes several dependency issues / warnings I received during my initial `npm install; npm run dep`.  After applying these fixes, I can finally get the application running.
- Change license to 3-clause BSD (which is what DSpace uses). Fixes a warning
- Fixes an error where `zone.js@~0.6.6` was not explicitly listed. (I've lost the exact error message, but there was a warning that it was no longer included automatically by "angular2-universal-preview" (IIRC)
- Fixes `rxjs` error: "The package rxjs@5.0.0-beta.3 does not satisfy its siblings' peerDependencies requirements! Peer angular2@2.0.0-beta.12 wants rxjs@5.0.0-beta.2"
- Minor README updates (to explain a fresh install better)
