### PR TITLE
Dependency cleanup / add WebPack comments

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,32 +26,29 @@
   },
   "dependencies": {
     "angular2": "2.0.0-beta.13",
-    "angular2-universal-preview": "~0.85.1",
-    "angular2-websocket": "^0.6.2",
+    "angular2-express-engine": "^0.7.1",
     "angular2-hapi-engine": "^0.7.2",
+    "angular2-universal-preview": "~0.85.1",
+    "angular2-universal-polyfills": "^0.3.1",
     "express": "^4.13.4",
     "jquery": "^2.2.2",
     "ng2-translate": "^1.11.0",
     "preboot": "^2.0.5",
-    "rxjs": "5.0.0-beta.2",
+    "rxjs": "^5.0.0-beta.2",
     "zone.js": "~0.6.8"
   },
   "devDependencies": {
     "bootstrap-loader": "^1.0.10",
     "bootstrap-sass": "^3.3.6",
-    "bootstrap-sass-loader": "^1.0.10",
     "commander": "^2.9.0",
     "concurrently": "^2.0.0",
     "copy-webpack-plugin": "^1.1.1",
     "css-loader": "^0.23.1",
-    "file-loader": "^0.8.5",
     "http-proxy": "^1.13.2",
     "node-sass": "^3.4.2",
     "nodemon": "^1.9.1",
-    "resolve-url-loader": "^1.4.3",
     "rimraf": "^2.5.2",
     "sass-loader": "^3.2.0",
-    "ssl-root-cas": "^1.1.10",
     "style-loader": "^0.13.1",
     "ts-loader": "^0.8.1",
     "typedoc": "^0.3.12",
@@ -59,8 +56,6 @@
     "typings": "^0.7.12",
     "url-loader": "^0.5.7",
     "webpack": "^1.12.14",
-    "webpack-dev-server": "^1.14.1",
-    "webpack-merge": "^0.8.4",
-    "ws": "^1.0.1"
+    "webpack-merge": "^0.8.4"
   }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,44 +3,65 @@ var webpack = require('webpack');
 var path = require('path');
 var CopyWebpackPlugin = require('copy-webpack-plugin');
 
+// Default configuration
 var defaultConfig = {
     module: {
+        // Do not parse these directories for source modules/files
         noParse: [
             path.join(__dirname, 'zone.js', 'dist'),
             path.join(__dirname, 'angular2', 'bundles')
         ]
     },
+    // Our base directory is the same directory as this webpack.config.js (i.e. [src])
     context: __dirname,
     resolve: {
+        // Directory that contains our modules is [src]/src
         root: path.join(__dirname, '/src')
     },
     output: {
+        // Public path of any resources used by browser
         publicPath: path.resolve(__dirname),
+        // Specifies the name of each output file on disk.
         filename: 'bundle.js'
     }
 }
 
+// Common / shared configuration (shared between client and server side configs below)
 var commonConfig = {
+     // An array of extensions that should be used to resolve modules.
+     // (These are the types of source files we have in our source code)
     resolve: {
         extensions: ['', '.css', '.scss', '.js', '.ts']
     },
     module: {
         loaders: [
+          // Typescript loader support for .ts (TypeScript files). Processes all TypeScript files
+          // See: https://github.com/TypeStrong/ts-loader
             {
-                test: /\.ts$/, 
+                test: /\.ts$/,
                 loader: 'ts-loader'
             }
         ]
     },
+    // Additional compiler plugins
     plugins: [
+        // OccurenceOrderPlugin - varies the distribution of the ids to get the smallest id length
+        // for often used ids
+        // See: https://webpack.github.io/docs/list-of-plugins.html#occurrenceorderplugin
+        // See: https://github.com/webpack/docs/wiki/optimization#minimize
         new webpack.optimize.OccurenceOrderPlugin(true),
+        // Tell WebPack to prepend `var $ = require("jquery")` whenever it
+        // encounters the global $ identifier. See: http://stackoverflow.com/a/28989476/3750035
         new webpack.ProvidePlugin({ $: "jquery", jQuery: "jquery" })
     ]
 };
 
-
+// Client-side specific configuration. Builds all client-side code.
 var clientConfig = {
+    // Cache modules to improve performance (in builds)
     cache: true,
+    // Entry point for the bundle (i.e. directory or files).
+    // This creates multiple entries of different names: 'app', 'styles', 'bootstrap'
     entry: {
         "app": "./src/app/boot",
         "styles": [
@@ -51,21 +72,31 @@ var clientConfig = {
         ]
     },
     output: {
+        // The output directory as absolute path (required).
         path: __dirname,
+        // Specifies the name of each output file on disk.
+        // [name] references the name ofthe "entry" point (see 'entry' above)
         filename: "./dist/[name].bundle.js"
     },
+    // Emit a "SourceMap". Makes it easier to debug the application, as
+    // it will tell you exactly where an error is raised
     devtool: 'source-map',
     module: {
-        loaders: [            
+        loaders: [
             {
+                // Process all .scss files using the
+                // style-loader, css-loader and sass-loader
                 test: /\.scss$/,
                 loader: 'style!css!sass'
             },
             {
-                test: /bootstrap\/js\//, 
+                // Ensures all Bootstrap JS files have access to the jQuery object
+                test: /bootstrap\/js\//,
                 loader: 'imports?jQuery=jquery'
             },
             {
+                // Ensure all Boostrap image/fonts are available via url-loader
+                // This essentially just copies these assets to URLs in output
                 test: /\.woff($|\?)|\.woff2($|\?)|\.ttf($|\?)|\.eot($|\?)|\.svg($|\?)/,
                 loader: 'url-loader'
             }
@@ -79,10 +110,15 @@ var clientConfig = {
     ]
 };
 
+// Server-side configuration. Builds all server-side code.
 var serverConfig = {
+    // node = Compile for usage in a Node.js-like environment (i.e. server-side)
     target: 'node',
+    // Entry point for the bundle. Selects a single directory
     entry: './src/server',
     output: {
+        // The output directory as absolute path (required).
+        // In this case [src]/dist/server
         path: path.join(__dirname, 'dist', 'server')
     },
     externals: checkNodeImport,
@@ -97,9 +133,9 @@ var serverConfig = {
 
 
 module.exports = [
-    // Client
+    // Client configs
     webpackMerge({}, defaultConfig, commonConfig, clientConfig),
-    // Server
+    // Server configs
     webpackMerge({}, defaultConfig, commonConfig, serverConfig)
 ];
 


### PR DESCRIPTION
This PR performs some dependency cleanup based on my analysis of what dependencies we are actually using (and why). That analysis is in this wiki page:
https://github.com/DSpace-Labs/angular2-ui-prototype/wiki/Project-Dependencies
- As part of this analysis, I discovered several dependencies which are no longer used: `bootstrap-sass-loader` (replaced by `bootstrap-loader`), `file-loader`, `resolve-url-loader`, `ssl-root-cas`, `webpack-dev-server`, `ws`
- I also fixed warnings about not including: `angular2-express-engine` and `angular2-universal-polyfills` (both are now required by Angular Universal).
- Finally, I enhanced our `webpack.config.js` with some basic comments (which I think accurately describe how it works, but might need review).  This was helpful (to me) in understanding how it works and what dependencies (namely "loaders") it actually is using.

This PR is ready for review.  I've tested the install, build and watch scripts and everything still seems to work fine with these changes.
