### PR TITLE
Add back in bootstrap-sass-loader

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
   "devDependencies": {
     "bootstrap-loader": "^1.0.10",
     "bootstrap-sass": "^3.3.6",
+    "bootstrap-sass-loader": "^1.0.10",
     "commander": "^2.9.0",
     "concurrently": "^2.0.0",
     "copy-webpack-plugin": "^1.1.1",


### PR DESCRIPTION
One more fix.  We _do_ need `bootstrap-sass-loader` (for now).  While the `npm install` doesn't fail, the `npm run build` throws errors without it.

This is a tiny followup to #42
