### PR TITLE
Add initial Travis CI settings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+language: node_js
+node_js:
+  - "5"
+  - "4"
+
+# Install global module dependencies
+before_install:
+  - npm run global
+
+# 'npm install' runs automatically
+
+script:
+  # Test build process
+  - npm run build
+  # TODO: We should run some tests!


### PR DESCRIPTION
Initial `.travis.yml` to enable Travis CI builds for this application. 

Current it just runs:
- `npm run global`
- `npm install`
- `npm run build`

See also:
https://docs.travis-ci.com/user/languages/javascript-with-nodejs
