### PR TITLE
rc-1 style imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "@angular/platform-browser-dynamic": "2.0.0-rc.1",
     "@angular/platform-server": "2.0.0-rc.1",
     "@angular/router-deprecated": "2.0.0-rc.1",
-    "angular2": "2.0.0-beta.17",
     "angular2-universal": "0.100.3",
     "body-parser": "1.15.1",
     "bootstrap": "3.3.6",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "body-parser": "1.15.1",
     "bootstrap": "3.3.6",
     "express": "4.13.4",
-    "ng2-translate": "2.0.0",
+    "ng2-translate": "2.1.0",
     "object-hash": "1.1.2",
     "preboot": "2.0.10",
     "rxjs": "5.0.0-beta.6"

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,5 +1,5 @@
-import { Component, OnInit } from 'angular2/core';
-import { ROUTER_DIRECTIVES, RouteConfig, Router } from 'angular2/router';
+import { Component, OnInit } from '@angular/core';
+import { ROUTER_DIRECTIVES, RouteConfig, Router } from '@angular/router-deprecated';
 
 import { TranslateService, TranslatePipe } from "ng2-translate/ng2-translate";
 

--- a/src/app/dashboard.component.ts
+++ b/src/app/dashboard.component.ts
@@ -1,5 +1,5 @@
-import { Component } from 'angular2/core';
-import { ROUTER_DIRECTIVES } from 'angular2/router';
+import { Component } from '@angular/core';
+import { ROUTER_DIRECTIVES } from '@angular/router-deprecated';
 
 import { TranslatePipe } from "ng2-translate/ng2-translate";
 

--- a/src/app/dspace/authorization/login/login-form.component.ts
+++ b/src/app/dspace/authorization/login/login-form.component.ts
@@ -1,6 +1,6 @@
-import { Component } from 'angular2/core';
-import { Router } from 'angular2/router';
-import { FORM_DIRECTIVES, FormBuilder, NgForm } from 'angular2/common';
+import { Component } from '@angular/core';
+import { Router } from '@angular/router-deprecated';
+import { FORM_DIRECTIVES, FormBuilder, NgForm } from '@angular/common';
 
 import { TranslatePipe } from "ng2-translate/ng2-translate";
 

--- a/src/app/dspace/authorization/login/login-modal.component.ts
+++ b/src/app/dspace/authorization/login/login-modal.component.ts
@@ -1,7 +1,7 @@
-import { Component } from 'angular2/core';
-import { Router } from 'angular2/router';
+import { Component } from '@angular/core';
+import { Router } from '@angular/router-deprecated';
 
-import { FormBuilder, NgForm } from 'angular2/common';
+import { FormBuilder, NgForm } from '@angular/common';
 
 import { TranslatePipe } from "ng2-translate/ng2-translate";
 

--- a/src/app/dspace/authorization/login/login.component.ts
+++ b/src/app/dspace/authorization/login/login.component.ts
@@ -1,6 +1,6 @@
-import { Component } from 'angular2/core';
-import { Router } from 'angular2/router';
-import { Control, FormBuilder, Validators } from 'angular2/common';
+import { Component } from '@angular/core';
+import { Router } from '@angular/router-deprecated';
+import { Control, FormBuilder, Validators } from '@angular/common';
 
 import { AuthorizationService } from '../services/authorization.service';
 import { FormService } from '../../../utilities/form/form.service';

--- a/src/app/dspace/authorization/registration/registration.component.ts
+++ b/src/app/dspace/authorization/registration/registration.component.ts
@@ -1,4 +1,4 @@
-import { Component } from 'angular2/core';
+import { Component } from '@angular/core';
 import { TranslateService, TranslatePipe } from "ng2-translate/ng2-translate";
 
 import { BreadcrumbService } from '../../../navigation/services/breadcrumb.service';

--- a/src/app/dspace/authorization/services/authorization.service.ts
+++ b/src/app/dspace/authorization/services/authorization.service.ts
@@ -1,5 +1,5 @@
-import { Injectable, Inject } from 'angular2/core';
-import { Response } from 'angular2/http';
+import { Injectable, Inject } from '@angular/core';
+import { Response } from '@angular/http';
 import { Subject } from 'rxjs/Subject';
 import { Observable } from "rxjs/Observable";
 

--- a/src/app/dspace/components/collection-create.component.ts
+++ b/src/app/dspace/components/collection-create.component.ts
@@ -1,5 +1,5 @@
-import { Component } from 'angular2/core';
-import { Router } from 'angular2/router';
+import { Component } from '@angular/core';
+import { Router } from '@angular/router-deprecated';
 
 import {
     FORM_DIRECTIVES,
@@ -9,7 +9,7 @@ import {
     FormBuilder,
     NgForm,
     Validators
-} from 'angular2/common';
+} from '@angular/common';
 
 import { AuthorizationService } from '../authorization/services/authorization.service';
 import { ContextProviderService } from '../services/context-provider.service';

--- a/src/app/dspace/components/collection-view.component.ts
+++ b/src/app/dspace/components/collection-view.component.ts
@@ -1,5 +1,5 @@
-import { Component } from 'angular2/core';
-import { RouteConfig, RouterOutlet, RouteParams } from 'angular2/router';
+import { Component } from '@angular/core';
+import { RouteConfig, RouterOutlet, RouteParams } from '@angular/router-deprecated';
 
 import { DSpaceDirectory } from '../dspace.directory';
 import { Collection } from "../models/collection.model";

--- a/src/app/dspace/components/collection.component.ts
+++ b/src/app/dspace/components/collection.component.ts
@@ -1,5 +1,5 @@
-import { Component } from 'angular2/core';
-import { RouteConfig, RouterOutlet, RouteParams } from 'angular2/router';
+import { Component } from '@angular/core';
+import { RouteConfig, RouterOutlet, RouteParams } from '@angular/router-deprecated';
 
 import { DSpaceDirectory } from '../dspace.directory';
 import { BreadcrumbService } from '../../navigation/services/breadcrumb.service';

--- a/src/app/dspace/components/community-create.component.ts
+++ b/src/app/dspace/components/community-create.component.ts
@@ -1,5 +1,5 @@
-import { Component } from 'angular2/core';
-import { Router } from 'angular2/router';
+import { Component } from '@angular/core';
+import { Router } from '@angular/router-deprecated';
 
 import {
     FORM_DIRECTIVES,
@@ -9,7 +9,7 @@ import {
     FormBuilder,
     NgForm,
     Validators
-} from 'angular2/common';
+} from '@angular/common';
 
 import { AuthorizationService } from '../authorization/services/authorization.service';
 import { ContextProviderService } from '../services/context-provider.service';

--- a/src/app/dspace/components/community-view.component.ts
+++ b/src/app/dspace/components/community-view.component.ts
@@ -1,5 +1,5 @@
-import { Component } from 'angular2/core';
-import { RouteConfig, RouterOutlet, RouteParams } from 'angular2/router';
+import { Component } from '@angular/core';
+import { RouteConfig, RouterOutlet, RouteParams } from '@angular/router-deprecated';
 
 import { DSpaceDirectory } from '../dspace.directory';
 import { Community } from "../models/community.model";

--- a/src/app/dspace/components/community.component.ts
+++ b/src/app/dspace/components/community.component.ts
@@ -1,5 +1,5 @@
-import { Component } from 'angular2/core';
-import { RouteConfig, RouterOutlet, RouteParams } from 'angular2/router';
+﻿import { Component } from '@angular/core';
+import { RouteConfig, RouterOutlet, RouteParams } from '@angular/router-deprecated';
 
 import { DSpaceDirectory } from '../dspace.directory';
 import { BreadcrumbService } from '../../navigation/services/breadcrumb.service';

--- a/src/app/dspace/components/container-home.component.ts
+++ b/src/app/dspace/components/container-home.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input } from 'angular2/core';
+import { Component, Input } from '@angular/core';
 
 import { ContainerHomepage } from "../interfaces/container-homepage.interface";
 import { ContainerLogoComponent } from "./container-logo.component";

--- a/src/app/dspace/components/container-logo.component.ts
+++ b/src/app/dspace/components/container-logo.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input } from "angular2/core";
+import { Component, Input } from '@angular/core';
 
 import { Bitstream } from "../models/bitstream.model";
 

--- a/src/app/dspace/components/full-item-view.component.ts
+++ b/src/app/dspace/components/full-item-view.component.ts
@@ -1,5 +1,5 @@
-import { Component } from 'angular2/core';
-import { ROUTER_DIRECTIVES } from 'angular2/router';
+import { Component } from '@angular/core';
+import { ROUTER_DIRECTIVES } from '@angular/router-deprecated';
 
 import { TranslatePipe } from "ng2-translate/ng2-translate";
 

--- a/src/app/dspace/components/item-bitstream-add.component.ts
+++ b/src/app/dspace/components/item-bitstream-add.component.ts
@@ -3,7 +3,7 @@ import {
     EventEmitter,
     Input,
     Output
-} from 'angular2/core';
+} from '@angular/core';
 
 /**
  * 

--- a/src/app/dspace/components/item-create.component.ts
+++ b/src/app/dspace/components/item-create.component.ts
@@ -1,5 +1,5 @@
-import { Component } from 'angular2/core';
-import { Router } from 'angular2/router';
+import { Component } from '@angular/core';
+import { Router } from '@angular/router-deprecated';
 
 import {
     FORM_DIRECTIVES,
@@ -9,7 +9,7 @@ import {
     FormBuilder,
     NgForm,
     Validators
-} from 'angular2/common';
+} from '@angular/common';
 
 import { Observable } from 'rxjs/Rx';
 

--- a/src/app/dspace/components/item-list.component.ts
+++ b/src/app/dspace/components/item-list.component.ts
@@ -1,5 +1,5 @@
-import { Component, Input } from 'angular2/core';
-import { RouteParams } from 'angular2/router';
+import { Component, Input } from '@angular/core';
+import { RouteParams } from '@angular/router-deprecated';
 
 import { DSpaceDirectory } from '../dspace.directory';
 import { DSpaceService } from '../services/dspace.service';

--- a/src/app/dspace/components/item-metadata-input.component.ts
+++ b/src/app/dspace/components/item-metadata-input.component.ts
@@ -3,9 +3,9 @@ import {
     EventEmitter,
     Input,
     Output
-} from 'angular2/core';
+} from '@angular/core';
 
-import { FORM_DIRECTIVES, ControlGroup } from 'angular2/common';
+import { FORM_DIRECTIVES, ControlGroup } from '@angular/common';
 
 import { TranslatePipe } from "ng2-translate/ng2-translate";
 

--- a/src/app/dspace/components/item.component.ts
+++ b/src/app/dspace/components/item.component.ts
@@ -1,11 +1,11 @@
-import { Component } from 'angular2/core';
+import { Component } from '@angular/core';
 import {
     RouteConfig,
     RouterOutlet,
     RouteParams,
     CanDeactivate,
     ComponentInstruction
-} from 'angular2/router';
+} from '@angular/router-deprecated';
 
 import { DSpaceDirectory } from '../dspace.directory';
 import { BreadcrumbService } from '../../navigation/services/breadcrumb.service';

--- a/src/app/dspace/components/item/abstract.component.ts
+++ b/src/app/dspace/components/item/abstract.component.ts
@@ -1,4 +1,4 @@
-import {Component, Input, OnInit} from 'angular2/core';
+import {Component, Input, OnInit} from '@angular/core';
 
 import {TranslatePipe} from "ng2-translate/ng2-translate";
 

--- a/src/app/dspace/components/item/authors.component.ts
+++ b/src/app/dspace/components/item/authors.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnInit } from 'angular2/core';
+import { Component, Input, OnInit } from '@angular/core';
 
 import { TranslatePipe } from "ng2-translate/ng2-translate";
 

--- a/src/app/dspace/components/item/bitstreams.component.ts
+++ b/src/app/dspace/components/item/bitstreams.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input } from 'angular2/core';
+import { Component, Input } from '@angular/core';
 
 import { TranslatePipe } from "ng2-translate/ng2-translate";
 

--- a/src/app/dspace/components/item/date.component.ts
+++ b/src/app/dspace/components/item/date.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnInit } from 'angular2/core';
+import { Component, Input, OnInit } from '@angular/core';
 
 import { TranslatePipe } from "ng2-translate/ng2-translate";
 

--- a/src/app/dspace/components/item/full/full-bitstreams.component.ts
+++ b/src/app/dspace/components/item/full/full-bitstreams.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input } from 'angular2/core';
+import { Component, Input } from '@angular/core';
 
 import { TranslatePipe } from "ng2-translate/ng2-translate";
 

--- a/src/app/dspace/components/item/full/full-collections.component.ts
+++ b/src/app/dspace/components/item/full/full-collections.component.ts
@@ -1,5 +1,5 @@
-import { Component, Input } from 'angular2/core';
-import { ROUTER_DIRECTIVES } from 'angular2/router';
+import { Component, Input } from '@angular/core';
+import { ROUTER_DIRECTIVES } from '@angular/router-deprecated';
 
 import { TranslatePipe } from "ng2-translate/ng2-translate";
 

--- a/src/app/dspace/components/item/full/full-metadata.component.ts
+++ b/src/app/dspace/components/item/full/full-metadata.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input } from 'angular2/core';
+import { Component, Input } from '@angular/core';
 
 import { TranslatePipe } from "ng2-translate/ng2-translate";
 

--- a/src/app/dspace/components/item/item-collection.component.ts
+++ b/src/app/dspace/components/item/item-collection.component.ts
@@ -1,5 +1,5 @@
-import { Component, Input } from 'angular2/core';
-import { ROUTER_DIRECTIVES } from 'angular2/router';
+import { Component, Input } from '@angular/core';
+import { ROUTER_DIRECTIVES } from '@angular/router-deprecated';
 
 import { TranslatePipe } from "ng2-translate/ng2-translate";
 

--- a/src/app/dspace/components/item/list/list-entry.component.ts
+++ b/src/app/dspace/components/item/list/list-entry.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input } from 'angular2/core';
+import { Component, Input } from '@angular/core';
 
 import { ListMetadataComponent } from './list-metadata.component';
 import { ThumbnailComponent } from '../thumbnail.component';

--- a/src/app/dspace/components/item/list/list-metadata.component.ts
+++ b/src/app/dspace/components/item/list/list-metadata.component.ts
@@ -1,5 +1,5 @@
-import { Component, Input, OnInit } from 'angular2/core';
-import { ROUTER_DIRECTIVES } from 'angular2/router';
+import { Component, Input, OnInit } from '@angular/core';
+import { ROUTER_DIRECTIVES } from '@angular/router-deprecated';
 
 import { Item } from '../../../models/item.model';
 import { Metadatum } from '../../../models/metadatum.model';

--- a/src/app/dspace/components/item/metadata.component.ts
+++ b/src/app/dspace/components/item/metadata.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnInit } from 'angular2/core';
+import { Component, Input, OnInit } from '@angular/core';
 
 import { TranslatePipe } from "ng2-translate/ng2-translate";
 

--- a/src/app/dspace/components/item/thumbnail.component.ts
+++ b/src/app/dspace/components/item/thumbnail.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input } from 'angular2/core';
+import { Component, Input } from '@angular/core';
 
 import { TranslatePipe } from "ng2-translate/ng2-translate";
 

--- a/src/app/dspace/components/item/uri.component.ts
+++ b/src/app/dspace/components/item/uri.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnInit } from 'angular2/core';
+import { Component, Input, OnInit } from '@angular/core';
 
 import { TranslatePipe } from "ng2-translate/ng2-translate";
 

--- a/src/app/dspace/components/item/view-element.component.ts
+++ b/src/app/dspace/components/item/view-element.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input } from 'angular2/core';
+import { Component, Input } from '@angular/core';
 
 /**
  * Component for the collections of the simple-item-view.

--- a/src/app/dspace/components/simple-item-view.component.ts
+++ b/src/app/dspace/components/simple-item-view.component.ts
@@ -1,5 +1,5 @@
-import { Component } from 'angular2/core';
-import { ROUTER_DIRECTIVES } from 'angular2/router';
+import { Component } from '@angular/core';
+import { ROUTER_DIRECTIVES } from '@angular/router-deprecated';
 
 import { TranslatePipe } from "ng2-translate/ng2-translate";
 

--- a/src/app/dspace/dspace.constants.ts
+++ b/src/app/dspace/dspace.constants.ts
@@ -1,4 +1,4 @@
-import { Injectable } from 'angular2/core';
+﻿import { Injectable } from '@angular/core';
 
 /**
  * Some constants.

--- a/src/app/dspace/dspace.directory.ts
+++ b/src/app/dspace/dspace.directory.ts
@@ -1,4 +1,4 @@
-import { EventEmitter, Injectable } from 'angular2/core';
+import { EventEmitter, Injectable } from '@angular/core';
 
 import { DSpaceService } from './services/dspace.service';
 import { PagingStoreService } from './services/paging-store.service';

--- a/src/app/dspace/services/context-provider.service.ts
+++ b/src/app/dspace/services/context-provider.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Inject } from 'angular2/core';
+import { Injectable, Inject } from '@angular/core';
 import { Subject } from 'rxjs/Subject';
 import { Observable } from 'rxjs/Observable';
 

--- a/src/app/dspace/services/dspace.service.ts
+++ b/src/app/dspace/services/dspace.service.ts
@@ -1,5 +1,5 @@
-import { Injectable } from 'angular2/core';
-import { Response, URLSearchParams } from 'angular2/http';
+import { Injectable } from '@angular/core';
+import { Response, URLSearchParams } from '@angular/http';
 import { Observable } from "rxjs/Observable";
 
 import { HttpService } from '../../utilities/services/http.service';

--- a/src/app/dspace/services/paging-store.service.ts
+++ b/src/app/dspace/services/paging-store.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from 'angular2/core';
+import { Injectable } from '@angular/core';
 
 import { DSpaceConstants } from '../dspace.constants';
 

--- a/src/app/home.component.ts
+++ b/src/app/home.component.ts
@@ -1,4 +1,4 @@
-import { Component } from 'angular2/core';
+import { Component } from '@angular/core';
 
 import { TranslateService, TranslatePipe } from "ng2-translate/ng2-translate";
 

--- a/src/app/main.ts
+++ b/src/app/main.ts
@@ -8,9 +8,9 @@ import {
     BROWSER_HTTP_PROVIDERS
 } from 'angular2-universal';
 
-import { Http } from 'angular2/http';
+import { Http } from '@angular/http';
 
-import { provide } from 'angular2/core';
+import { provide } from '@angular/core';
 
 import {
     TranslateLoader,

--- a/src/app/navigation/components/breadcrumb.component.ts
+++ b/src/app/navigation/components/breadcrumb.component.ts
@@ -1,5 +1,5 @@
-import { Component, AfterViewInit, OnDestroy } from 'angular2/core';
-import { ROUTER_DIRECTIVES } from 'angular2/router';
+import { Component, AfterViewInit, OnDestroy } from '@angular/core';
+import { ROUTER_DIRECTIVES } from '@angular/router-deprecated';
 
 import { DSpaceDirectory } from '../../dspace/dspace.directory';
 import { BreadcrumbService } from '../services/breadcrumb.service';

--- a/src/app/navigation/components/context.component.ts
+++ b/src/app/navigation/components/context.component.ts
@@ -1,5 +1,5 @@
-import { Component } from 'angular2/core';
-import { ROUTER_DIRECTIVES } from 'angular2/router';
+import { Component } from '@angular/core';
+import { ROUTER_DIRECTIVES } from '@angular/router-deprecated';
 import { TranslatePipe } from "ng2-translate/ng2-translate";
 
 import { AuthorizationService } from '../../dspace/authorization/services/authorization.service';

--- a/src/app/navigation/components/list.component.ts
+++ b/src/app/navigation/components/list.component.ts
@@ -1,5 +1,5 @@
-import { Component, Input } from 'angular2/core';
-import { ROUTER_DIRECTIVES } from 'angular2/router';
+﻿import { Component, Input } from '@angular/core';
+import { ROUTER_DIRECTIVES } from '@angular/router-deprecated';
 
 import { Collection } from "../../dspace/models/collection.model";
 import { PaginationComponent } from './pagination.component';

--- a/src/app/navigation/components/pagination.component.ts
+++ b/src/app/navigation/components/pagination.component.ts
@@ -1,5 +1,5 @@
-import { Component, Input, OnInit } from 'angular2/core';
-import { ROUTER_DIRECTIVES, Router } from 'angular2/router';
+import { Component, Input, OnInit } from '@angular/core';
+import { ROUTER_DIRECTIVES, Router } from '@angular/router-deprecated';
 
 import { BreadcrumbService } from '../services/breadcrumb.service';
 import { DSpaceDirectory } from '../../dspace/dspace.directory';

--- a/src/app/navigation/components/tree.component.ts
+++ b/src/app/navigation/components/tree.component.ts
@@ -1,5 +1,5 @@
-import { Component, Input } from 'angular2/core';
-import { ROUTER_DIRECTIVES } from 'angular2/router';
+﻿import { Component, Input } from '@angular/core';
+import { ROUTER_DIRECTIVES } from '@angular/router-deprecated';
 
 import { ListComponent } from './list.component';
 import { PaginationComponent } from './pagination.component';

--- a/src/app/navigation/services/breadcrumb.service.ts
+++ b/src/app/navigation/services/breadcrumb.service.ts
@@ -1,5 +1,5 @@
-import { Injectable } from 'angular2/core';
-import { EventEmitter } from 'angular2/core';
+import { Injectable } from '@angular/core';
+import { EventEmitter } from '@angular/core';
 
 import { ContextProviderService } from '../../dspace/services/context-provider.service';
 

--- a/src/app/navigation/services/pagination.service.ts
+++ b/src/app/navigation/services/pagination.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from 'angular2/core';
+import { Injectable } from '@angular/core';
 
 /**
  * Injectable service to provide pagination controls array.

--- a/src/app/settings.component.ts
+++ b/src/app/settings.component.ts
@@ -1,4 +1,4 @@
-import { Component } from 'angular2/core';
+﻿import { Component } from '@angular/core';
 
 import { TranslatePipe } from "ng2-translate/ng2-translate";
 

--- a/src/app/setup.component.ts
+++ b/src/app/setup.component.ts
@@ -1,4 +1,4 @@
-import { Component } from 'angular2/core';
+﻿import { Component } from '@angular/core';
 
 import { TranslatePipe } from "ng2-translate/ng2-translate";
 

--- a/src/app/utilities/form/form-fieldset.component.ts
+++ b/src/app/utilities/form/form-fieldset.component.ts
@@ -1,5 +1,5 @@
-import { Component, Inject, Input } from 'angular2/core';
-import { ControlGroup } from 'angular2/common';
+import { Component, Inject, Input } from '@angular/core';
+import { ControlGroup } from '@angular/common';
 
 import { ValidationMessageComponent } from './validation-message.component';
 

--- a/src/app/utilities/form/form-focus.directive.ts
+++ b/src/app/utilities/form/form-focus.directive.ts
@@ -1,4 +1,4 @@
-import { Directive, ElementRef, Input, OnChanges } from 'angular2/core';
+import { Directive, ElementRef, Input, OnChanges } from '@angular/core';
 
 /**
  * 

--- a/src/app/utilities/form/form-modal.component.ts
+++ b/src/app/utilities/form/form-modal.component.ts
@@ -4,9 +4,9 @@ import {
     Output,
     EventEmitter,
     OnInit
-} from 'angular2/core';
+} from '@angular/core';
 
-import { ControlGroup, NgForm } from 'angular2/common';
+import { ControlGroup, NgForm } from '@angular/common';
 
 import { TranslatePipe } from "ng2-translate/ng2-translate";
 

--- a/src/app/utilities/form/form-secure.component.ts
+++ b/src/app/utilities/form/form-secure.component.ts
@@ -1,6 +1,6 @@
-import { OnActivate, ComponentInstruction, Router } from 'angular2/router';
+import { OnActivate, ComponentInstruction, Router } from '@angular/router-deprecated';
 
-import { FormBuilder } from 'angular2/common';
+import { FormBuilder } from '@angular/common';
 
 import { AuthorizationService } from '../../dspace/authorization/services/authorization.service';
 import { FormService } from './form.service';

--- a/src/app/utilities/form/form.component.ts
+++ b/src/app/utilities/form/form.component.ts
@@ -1,7 +1,7 @@
-import { ControlGroup, Validators } from 'angular2/common';
-import { Router } from 'angular2/router';
+import { ControlGroup, Validators } from '@angular/common';
+import { Router } from '@angular/router-deprecated';
 
-import { FormBuilder } from 'angular2/common';
+import { FormBuilder } from '@angular/common';
 
 import { AuthorizationService } from '../../dspace/authorization/services/authorization.service';
 import { FormService } from './form.service';

--- a/src/app/utilities/form/form.interface.ts
+++ b/src/app/utilities/form/form.interface.ts
@@ -1,4 +1,4 @@
-import { ControlGroup } from 'angular2/common';
+import { ControlGroup } from '@angular/common';
 
 import { FormInput } from './form-input.model';
 

--- a/src/app/utilities/form/form.service.ts
+++ b/src/app/utilities/form/form.service.ts
@@ -1,5 +1,5 @@
-import { Injectable } from 'angular2/core';
-import { Validators } from 'angular2/common';
+import { Injectable } from '@angular/core';
+import { Validators } from '@angular/common';
 
 import { Observable } from "rxjs/Observable";
 

--- a/src/app/utilities/form/full-page-loader.component.ts
+++ b/src/app/utilities/form/full-page-loader.component.ts
@@ -1,4 +1,4 @@
-import { Component } from 'angular2/core';
+import { Component } from '@angular/core';
 
 /**
  * 

--- a/src/app/utilities/form/validation-message.component.ts
+++ b/src/app/utilities/form/validation-message.component.ts
@@ -1,6 +1,6 @@
-import { Component, Input } from 'angular2/core';
+import { Component, Input } from '@angular/core';
 
-import { FORM_DIRECTIVES, ControlGroup } from 'angular2/common';
+import { FORM_DIRECTIVES, ControlGroup } from '@angular/common';
 
 import { TranslateService, TranslatePipe } from "ng2-translate/ng2-translate";
 

--- a/src/app/utilities/meta-tag/meta-tag.service.ts
+++ b/src/app/utilities/meta-tag/meta-tag.service.ts
@@ -1,6 +1,6 @@
-import { DOM } from "angular2/src/platform/dom/dom_adapter";
-import { Injectable, Inject } from "angular2/core";
-import { DOCUMENT } from 'angular2/platform/common_dom';
+import {getDOM} from '@angular/platform-browser/src/dom/dom_adapter';
+import { Injectable, Inject } from "@angular/core";
+import { DOCUMENT } from '@angular/platform-browser';
 
 import { MetaTag } from "./meta-tag.model";
 import { ArrayUtil } from "../commons/array.util";
@@ -90,21 +90,21 @@ export class MetaTagService {
      *      a Node representing that <meta> element
      */
     private metaTagToNode(newTag: MetaTag): Node {
-        let meta = DOM.createElement('meta');
+        let meta = getDOM().createElement('meta');
         if (ObjectUtil.isNotEmpty(newTag.id)) {
-            DOM.setAttribute(meta, 'id', newTag.id);
+            getDOM().setAttribute(meta, 'id', newTag.id);
         }
         if (ObjectUtil.isNotEmpty(newTag.name)) {
-            DOM.setAttribute(meta, 'name', newTag.name);
+            getDOM().setAttribute(meta, 'name', newTag.name);
         }
         if (ObjectUtil.isNotEmpty(newTag.content)) {
-            DOM.setAttribute(meta, 'content', newTag.content);
+            getDOM().setAttribute(meta, 'content', newTag.content);
         }
         if (ObjectUtil.isNotEmpty(newTag.scheme)) {
-            DOM.setAttribute(meta, 'scheme', newTag.scheme);
+            getDOM().setAttribute(meta, 'scheme', newTag.scheme);
         }
         if (ObjectUtil.isNotEmpty(newTag.lang)) {
-            DOM.setAttribute(meta, 'xml:lang', newTag.lang);
+            getDOM().setAttribute(meta, 'xml:lang', newTag.lang);
         }
         return meta;
     }
@@ -233,10 +233,10 @@ export class MetaTagService {
     private insertMetaNodeIntoDOM(meta: Node): void {
         let lastMetaNode = this.getLastMetaNode();
         if (ObjectUtil.hasValue(lastMetaNode)) {
-            DOM.insertAfter(lastMetaNode, meta);
+            getDOM().insertAfter(lastMetaNode, meta);
         }
         else {
-            DOM.insertBefore(this._document.head.firstChild, meta);
+            getDOM().insertBefore(this._document.head.firstChild, meta);
         }
     }
 
@@ -296,7 +296,7 @@ export class MetaTagService {
      * from the DOM and the internal MetaTag arrays.
      *
      * @param tagsToRemove
-     *      the list of MetaTag objects to remove.      
+     *      the list of MetaTag objects to remove.
      */
     public removeTags(tagsToRemove: Array<MetaTag>): void {
         if (ArrayUtil.isNotEmpty(tagsToRemove)) {

--- a/src/app/utilities/meta-tag/meta-tag.service.ts
+++ b/src/app/utilities/meta-tag/meta-tag.service.ts
@@ -1,4 +1,4 @@
-import {getDOM} from '@angular/platform-browser/src/dom/dom_adapter';
+import { getDOM } from '@angular/platform-browser/src/dom/dom_adapter';
 import { Injectable, Inject } from "@angular/core";
 import { DOCUMENT } from '@angular/platform-browser';
 

--- a/src/app/utilities/metadata.helper.ts
+++ b/src/app/utilities/metadata.helper.ts
@@ -1,4 +1,4 @@
-import { Injectable } from 'angular2/core';
+import { Injectable } from '@angular/core';
 import { Metadatum } from '../dspace/models/metadatum.model'
 
 /**

--- a/src/app/utilities/pipes/truncate.pipe.ts
+++ b/src/app/utilities/pipes/truncate.pipe.ts
@@ -1,4 +1,4 @@
-import { Pipe, PipeTransform } from 'angular2/core'
+import { Pipe, PipeTransform } from '@angular/core'
 import { ObjectUtil } from "../commons/object.util";
 
 /**

--- a/src/app/utilities/pipes/truncatedate.pipe.ts
+++ b/src/app/utilities/pipes/truncatedate.pipe.ts
@@ -1,4 +1,4 @@
-import { Pipe, PipeTransform } from 'angular2/core'
+import { Pipe, PipeTransform } from '@angular/core'
 
 /**
  * Pipe to truncate a value in Angular2. (Take a substring, starting at 0)

--- a/src/app/utilities/services/google-scholar-metadata.service.ts
+++ b/src/app/utilities/services/google-scholar-metadata.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Inject } from 'angular2/core';
+import { Injectable, Inject } from '@angular/core';
 
 import { ArrayUtil } from "../commons/array.util";
 import { StringUtil } from "../commons/string.util";

--- a/src/app/utilities/services/http.service.ts
+++ b/src/app/utilities/services/http.service.ts
@@ -1,4 +1,4 @@
-import { Injectable} from 'angular2/core';
+import { Injectable} from '@angular/core';
 import {
     Http,
     Headers,
@@ -6,7 +6,7 @@ import {
     Request,
     RequestMethod,
     Response
-} from 'angular2/http';
+} from '@angular/http';
 
 import { Observable } from 'rxjs/Rx';
 

--- a/src/app/utilities/services/storage.service.ts
+++ b/src/app/utilities/services/storage.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from 'angular2/core';
+import { Injectable } from '@angular/core';
 
 /**
  * 

--- a/src/server/head.component.ts
+++ b/src/server/head.component.ts
@@ -1,4 +1,4 @@
-import { Component } from 'angular2/core';
+import { Component } from '@angular/core';
 
 /**
  * Title component for server side rendering of the title.

--- a/src/server/title.component.ts
+++ b/src/server/title.component.ts
@@ -1,4 +1,4 @@
-import { Component } from 'angular2/core';
+import { Component } from '@angular/core';
 
 /**
  * Title component for server side rendering of the title.


### PR DESCRIPTION
Replaces all `angular2` imports with their `@angular` counterparts, for compatibility with rc-1

This PR closes #95 
