### PR TITLE
update angular2-universal

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@angular/platform-browser-dynamic": "2.0.0-rc.1",
     "@angular/platform-server": "2.0.0-rc.1",
     "@angular/router-deprecated": "2.0.0-rc.1",
-    "angular2-universal": "0.100.3",
+    "angular2-universal": "0.101.3",
     "body-parser": "1.15.1",
     "bootstrap": "3.3.6",
     "express": "4.13.4",


### PR DESCRIPTION
When removing the node_modules and _dist I started getting a lot of errors. A colleague of mine had the same, eventually loading the webpage would result in

`component.map -> function not found` in bootloader.js.

Updating the angular2-universal dependency solved the problem
