### PR TITLE
Fixes #114 : Refactor DSpaceDirectory to DSpaceHierarchyService

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -5,7 +5,7 @@ import { TranslateService, TranslatePipe } from "ng2-translate/ng2-translate";
 import { CollapseDirective } from 'ng2-bootstrap/ng2-bootstrap';
 
 import { AuthorizationService } from './dspace/authorization/services/authorization.service';
-import { DSpaceDirectory } from './dspace/dspace.directory';
+import { DSpaceHierarchyService } from './dspace/services/dspace-hierarchy.service';
 
 import { BreadcrumbComponent } from './navigation/components/breadcrumb.component';
 import { CollectionComponent } from './dspace/components/collection.component';
@@ -123,7 +123,7 @@ export class AppComponent implements OnInit {
     /**
      *
      * @param dspace
-     *      DSpaceDirectory is a singleton service to interact with the dspace directory.
+     *      DSpaceHierarchyService is a singleton service to interact with the dspace hierarchy.
      * @param authorization
      *      AuthorizationService is a singleton service to interact with the authorization service.
      * @param translate
@@ -131,7 +131,7 @@ export class AppComponent implements OnInit {
      * @param router
      *      Router is a singleton service provided by Angular2.
      */
-    constructor(private dspace: DSpaceDirectory,
+    constructor(private dspace: DSpaceHierarchyService,
                 private authorization: AuthorizationService,
                 private translate: TranslateService,
                 private router: Router) {
@@ -147,7 +147,7 @@ export class AppComponent implements OnInit {
      * Method provided by Angular2. Invoked after the constructor.
      */
     ngOnInit() {
-        this.dspace.loadDirectory();
+        this.dspace.loadHierarchy();
     }
 
     /**

--- a/src/app/dashboard.component.ts
+++ b/src/app/dashboard.component.ts
@@ -4,7 +4,7 @@ import { ROUTER_DIRECTIVES } from '@angular/router-deprecated';
 import { TranslatePipe } from "ng2-translate/ng2-translate";
 
 import { BreadcrumbService } from './navigation/services/breadcrumb.service';
-import { DSpaceDirectory } from './dspace/dspace.directory';
+import { DSpaceHierarchyService } from './dspace/services/dspace-hierarchy.service';
 
 import { PaginationComponent } from './navigation/components/pagination.component';
 import { TreeComponent } from './navigation/components/tree.component';
@@ -12,29 +12,29 @@ import { TreeComponent } from './navigation/components/tree.component';
 import { Breadcrumb } from './navigation/models/breadcrumb.model';
 
 /**
- * The dashboard component is the main index for browsing. Layout contains a 
+ * The dashboard component is the main index for browsing. Layout contains a
  * sidebar context along with the community/collection/item tree.
  */
 @Component({
-    selector: "directory",
+    selector: "hierarchy",
     pipes: [ TranslatePipe ],
     directives: [ TreeComponent ],
     template: `
-                <tree [directories]="dspace.directory"></tree>
+                <tree [hierarchies]="dspace.hierarchy"></tree>
               `
 })
 export class DashboardComponent {
-        
+
     private breadcrumb: Breadcrumb = new Breadcrumb('dashboard', true);
 
     /**
      *
-     * @param dspace 
-     *      DSpaceDirectory is a singleton service to interact with the dspace directory.
+     * @param dspace
+     *      DSpaceHierarchyService is a singleton service to interact with the dspace hierarchy.
      * @param breadcrumbService
      *      BreadcrumbService is a singleton service to interact with the breadcrumb component.
      */
-    constructor(private dspace: DSpaceDirectory,
+    constructor(private dspace: DSpaceHierarchyService,
                 private breadcrumbService: BreadcrumbService) {
         breadcrumbService.visit(this.breadcrumb);
     }

--- a/src/app/dspace/components/collection-create.component.ts
+++ b/src/app/dspace/components/collection-create.component.ts
@@ -15,7 +15,7 @@ import { TranslateService } from "ng2-translate/ng2-translate";
 import { AuthorizationService } from '../authorization/services/authorization.service';
 import { ContextProviderService } from '../services/context-provider.service';
 import { DSpaceService } from '../services/dspace.service';
-import { DSpaceDirectory } from '../dspace.directory';
+import { DSpaceHierarchyService } from '../services/dspace-hierarchy.service';
 import { FormService } from '../../utilities/form/form.service';
 import { NotificationService } from '../../utilities/notification/notification.service';
 
@@ -27,12 +27,12 @@ import { Collection } from "../models/collection.model";
 import { FormInput } from '../../utilities/form/form-input.model';
 
 /**
- * 
+ *
  */
 @Component({
     selector: 'collection-create',
     directives: [ FormFieldsetComponent, LoaderComponent ],
-    template: ` 
+    template: `
                 <h3>Create Collection</h3><hr>
                 <loader *ngIf="processing" [message]="processingMessage()"></loader>
                 <form *ngIf="showForm()" [ngFormModel]="form" (ngSubmit)="createCollection()" novalidate>
@@ -60,7 +60,7 @@ export class CollectionCreateComponent extends FormSecureComponent {
      * @param dspaceService
      *      DSpaceService is a singleton service to interact with the dspace service.
      * @param dspace
-     *      DSpaceDirectory is a singleton service to interact with the dspace directory.
+     *      DSpaceHierarchyService is a singleton service to interact with the dspace hierarchy.
      * @param notificationService
      *      NotificationService is a singleton service to notify user of alerts.
      * @param formService
@@ -75,7 +75,7 @@ export class CollectionCreateComponent extends FormSecureComponent {
     constructor(private translate: TranslateService,
                 private contextProvider: ContextProviderService,
                 private dspaceService: DSpaceService,
-                private dspace: DSpaceDirectory,
+                private dspace: DSpaceHierarchyService,
                 private notificationService: NotificationService,
                 formService: FormService,
                 builder: FormBuilder,

--- a/src/app/dspace/components/collection.component.ts
+++ b/src/app/dspace/components/collection.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 import { RouteParams } from '@angular/router-deprecated';
 
-import { DSpaceDirectory } from '../dspace.directory';
+import { DSpaceHierarchyService } from '../services/dspace-hierarchy.service';
 import { BreadcrumbService } from '../../navigation/services/breadcrumb.service';
 
 import { ContainerHomeComponent } from "./container-home.component";
@@ -16,7 +16,7 @@ import { Collection } from "../models/collection.model";
 @Component({
     selector: 'collection',
     directives: [ ContainerHomeComponent, ItemListComponent ],
-    template: ` 
+    template: `
                 <div *ngIf="collectionProvided()">
                     <container-home [container]="collection"></container-home>
                     <item-list *ngIf="collection.items.length > 0" [collection]="collection" [items]="collection.items"></item-list>
@@ -35,12 +35,12 @@ export class CollectionComponent {
      * @param params
      *      RouteParams is a service provided by Angular2 that contains the current routes parameters.
      * @param dspace
-     *      DSpaceDirectory is a singleton service to interact with the dspace directory.
+     *      DSpaceHierarchyService is a singleton service to interact with the dspace hierarchy.
      * @param breadcrumbService
      *      BreadcrumbService is a singleton service to interact with the breadcrumb component.
      */
-    constructor(private params: RouteParams, 
-                private dspace: DSpaceDirectory, 
+    constructor(private params: RouteParams,
+                private dspace: DSpaceHierarchyService,
                 private breadcrumbService: BreadcrumbService) {
         dspace.loadObj('collection', params.get('id'), params.get('page'), params.get('limit')).then((collection:Collection) => {
             this.collection = collection;

--- a/src/app/dspace/components/community-create.component.ts
+++ b/src/app/dspace/components/community-create.component.ts
@@ -15,7 +15,7 @@ import { TranslateService } from "ng2-translate/ng2-translate";
 import { AuthorizationService } from '../authorization/services/authorization.service';
 import { ContextProviderService } from '../services/context-provider.service';
 import { DSpaceService } from '../services/dspace.service';
-import { DSpaceDirectory } from '../dspace.directory';
+import { DSpaceHierarchyService } from '../services/dspace-hierarchy.service';
 import { FormService } from '../../utilities/form/form.service';
 import { NotificationService } from '../../utilities/notification/notification.service';
 
@@ -27,12 +27,12 @@ import { Community } from "../models/community.model";
 import { FormInput } from '../../utilities/form/form-input.model';
 
 /**
- * 
+ *
  */
 @Component({
     selector: 'community-create',
     directives: [ FormFieldsetComponent, LoaderComponent ],
-    template: ` 
+    template: `
                 <h3>Create Community</h3><hr>
                 <loader *ngIf="processing" [message]="processingMessage()"></loader>
                 <form *ngIf="showForm()" [ngFormModel]="form" (ngSubmit)="createCommunity()" novalidate>
@@ -60,7 +60,7 @@ export class CommunityCreateComponent extends FormSecureComponent {
      * @param dspaceService
      *      DSpaceService is a singleton service to interact with the dspace service.
      * @param dspace
-     *      DSpaceDirectory is a singleton service to interact with the dspace directory.
+     *      DSpaceHierarchyService is a singleton service to interact with the dspace hierarchy.
      * @param notificationService
      *      NotificationService is a singleton service to notify user of alerts.
      * @param formService
@@ -75,7 +75,7 @@ export class CommunityCreateComponent extends FormSecureComponent {
     constructor(private translate: TranslateService,
                 private contextProvider: ContextProviderService,
                 private dspaceService: DSpaceService,
-                private dspace: DSpaceDirectory,
+                private dspace: DSpaceHierarchyService,
                 private notificationService: NotificationService,
                 formService: FormService,
                 builder: FormBuilder,

--- a/src/app/dspace/components/community.component.ts
+++ b/src/app/dspace/components/community.component.ts
@@ -19,7 +19,7 @@ import { Community } from "../models/community.model";
     template: `
                 <div *ngIf="communityProvided()">
                     <container-home [container]="community"></container-home>
-                    <tree [directories]="subCommunitiesAndCollections(community)"></tree>
+                    <tree [hierarchies]="subCommunitiesAndCollections(community)"></tree>
                 </div>
               `
 })
@@ -39,7 +39,7 @@ export class CommunityComponent {
      * @param params
      *      RouteParams is a service provided by Angular2 that contains the current routes parameters.
      */
-    constructor(private dspace: DSpaceHierarchyService, 
+    constructor(private dspace: DSpaceHierarchyService,
                 private breadcrumb: BreadcrumbService,
                 private params: RouteParams) {
         dspace.loadObj('community', params.get('id'), params.get('page'), params.get('limit')).then((community:Community) => {

--- a/src/app/dspace/components/community.component.ts
+++ b/src/app/dspace/components/community.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 import { RouteParams } from '@angular/router-deprecated';
 
-import { DSpaceDirectory } from '../dspace.directory';
+import { DSpaceHierarchyService } from '../services/dspace-hierarchy.service';
 import { BreadcrumbService } from '../../navigation/services/breadcrumb.service';
 
 import { ContainerHomeComponent } from "./container-home.component.ts";
@@ -16,7 +16,7 @@ import { Community } from "../models/community.model";
 @Component({
     selector: 'community',
     directives: [ ContainerHomeComponent, TreeComponent ],
-    template: ` 
+    template: `
                 <div *ngIf="communityProvided()">
                     <container-home [container]="community"></container-home>
                     <tree [directories]="subCommunitiesAndCollections(community)"></tree>
@@ -33,13 +33,13 @@ export class CommunityComponent {
     /**
      *
      * @param dspace
-     *      DSpaceDirectory is a singleton service to interact with the dspace directory.
+     *      DSpaceHierarchyService is a singleton service to interact with the dspace hierarchy.
      * @param breadcrumb
      *      BreadcrumbService is a singleton service to interact with the breadcrumb component.
      * @param params
      *      RouteParams is a service provided by Angular2 that contains the current routes parameters.
      */
-    constructor(private dspace: DSpaceDirectory, 
+    constructor(private dspace: DSpaceHierarchyService, 
                 private breadcrumb: BreadcrumbService,
                 private params: RouteParams) {
         dspace.loadObj('community', params.get('id'), params.get('page'), params.get('limit')).then((community:Community) => {

--- a/src/app/dspace/components/item-create.component.ts
+++ b/src/app/dspace/components/item-create.component.ts
@@ -17,7 +17,7 @@ import { TranslateService } from "ng2-translate/ng2-translate";
 import { AuthorizationService } from '../authorization/services/authorization.service';
 import { ContextProviderService } from '../services/context-provider.service';
 import { DSpaceService } from '../services/dspace.service';
-import { DSpaceDirectory } from '../dspace.directory';
+import { DSpaceHierarchyService } from '../services/dspace-hierarchy.service';
 import { FormService } from '../../utilities/form/form.service';
 import { NotificationService } from '../../utilities/notification/notification.service';
 
@@ -87,7 +87,7 @@ export class ItemCreateComponent extends FormSecureComponent {
      * @param dspaceService
      *      DSpaceService is a singleton service to interact with the dspace service.
      * @param dspace
-     *      DSpaceDirectory is a singleton service to interact with the dspace directory.
+     *      DSpaceHierarchyService is a singleton service to interact with the dspace hierarchy.
      * @param notificationService
      *      NotificationService is a singleton service to notify user of alerts.
      * @param formService
@@ -102,7 +102,7 @@ export class ItemCreateComponent extends FormSecureComponent {
     constructor(private translate: TranslateService,
                 private contextProvider: ContextProviderService,
                 private dspaceService: DSpaceService,
-                private dspace: DSpaceDirectory,
+                private dspace: DSpaceHierarchyService,
                 private notificationService: NotificationService,
                 formService: FormService,
                 builder: FormBuilder,
@@ -132,7 +132,7 @@ export class ItemCreateComponent extends FormSecureComponent {
             this.active = true;
         },
         errors => {
-            console.log(errors);
+            console.error('Error: ' + errors);
         });
     }
 
@@ -282,7 +282,7 @@ export class ItemCreateComponent extends FormSecureComponent {
             }
         },
         error => {
-            console.log(error);
+            console.error(error);
             this.processing = false;
             this.notificationService.notify('app', 'DANGER', this.translate.instant('item.create.error', { name: this.item.name }));
         });

--- a/src/app/dspace/components/item-list.component.ts
+++ b/src/app/dspace/components/item-list.component.ts
@@ -1,7 +1,7 @@
 import { Component, Input } from '@angular/core';
 import { RouteParams } from '@angular/router-deprecated';
 
-import { DSpaceDirectory } from '../dspace.directory';
+import { DSpaceHierarchyService } from '../services/dspace-hierarchy.service';
 import { DSpaceService } from '../services/dspace.service';
 
 import { ListEntryComponent } from './item/list/list-entry.component';

--- a/src/app/dspace/components/item.component.ts
+++ b/src/app/dspace/components/item.component.ts
@@ -7,7 +7,7 @@ import {
     ComponentInstruction
 } from '@angular/router-deprecated';
 
-import { DSpaceDirectory } from '../dspace.directory';
+import { DSpaceHierarchyService } from '../services/dspace-hierarchy.service';
 import { BreadcrumbService } from '../../navigation/services/breadcrumb.service';
 import { GoogleScholarMetadataService } from "../../utilities/services/google-scholar-metadata.service.ts";
 import { MetaTagService } from "../../utilities/meta-tag/meta-tag.service";
@@ -31,7 +31,7 @@ import { Item } from "../models/item.model";
               `
 })
 @RouteConfig([
-    
+
         { path: "/", name: "SimpleItemView", component: SimpleItemViewComponent, useAsDefault: true },
         { path: "/full", name: "FullItemView", component: FullItemViewComponent },
 
@@ -45,13 +45,13 @@ export class ItemComponent implements CanDeactivate {
      * @param params
      *      RouteParams is a service provided by Angular2 that contains the current routes parameters.
      * @param dspace
-     *      DSpaceDirectory is a singleton service to interact with the dspace directory.
+     *      DSpaceHierarchyService is a singleton service to interact with the dspace hierarchy.
      * @param breadcrumbService
      *      BreadcrumbService is a singleton service to interact with the breadcrumb component.
      * @param gsMeta
      *      GoogleScholarMetadataService is a singleton service to set the <meta> tags for google scholar
      */
-    constructor(private dspace: DSpaceDirectory,
+    constructor(private dspace: DSpaceHierarchyService,
                 private breadcrumbService: BreadcrumbService,
                 private gsMeta: GoogleScholarMetadataService,
                 private params: RouteParams) {

--- a/src/app/dspace/models/pageable.model.ts
+++ b/src/app/dspace/models/pageable.model.ts
@@ -2,7 +2,7 @@ import { Paging } from "../interfaces/paging.interface";
 import { ObjectUtil } from "../../utilities/commons/object.util";
 
 /**
- * 
+ *
  */
 export abstract class Pageable implements Paging {
 
@@ -51,7 +51,7 @@ export abstract class Pageable implements Paging {
      *
      * @param json
      *      A plain old javascript object representing an Pageable as would be returned
-     *      from the directory service. It uses json.ready, json.offset, json.page,
+     *      from the hierarchy service. It uses json.ready, json.offset, json.page,
      *      json.limit, json.component, json.pageCount, and json.total
      */
     constructor(json?: any) {
@@ -68,7 +68,7 @@ export abstract class Pageable implements Paging {
     }
 
     /**
-     * 
+     *
      */
     sanitize(): void {
         this.ready = undefined;

--- a/src/app/dspace/services/dspace-constants.service.ts
+++ b/src/app/dspace/services/dspace-constants.service.ts
@@ -1,10 +1,10 @@
 ﻿import { Injectable } from '@angular/core';
 
 /**
- * Some constants.
+ * Service which provides some constants for interaction with the DSpace REST API
  */
 @Injectable()
-export class DSpaceConstants {
+export class DSpaceConstantsService {
 
     /**
      * Constants for items

--- a/src/app/dspace/services/paging-store.service.ts
+++ b/src/app/dspace/services/paging-store.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 
-import { DSpaceConstants } from '../dspace.constants';
+import { DSpaceConstantsService } from './dspace-constants.service';
 
 /**
  * Injectable service to cache session context which have been visited.
@@ -9,12 +9,12 @@ import { DSpaceConstants } from '../dspace.constants';
  */
 @Injectable()
 export class PagingStoreService {
-    
+
     /**
      * A map of the visited item pages.
      */
     private itemPages: Map<number, any>;
-    
+
     /**
      * A map of the visited collection pages.
      */
@@ -24,13 +24,13 @@ export class PagingStoreService {
      * A map of the visited community pages.
      */
     private communityPages: Map<number, any>;
-    
+
     /**
-     * 
+     *
      * @param dspaceConstants
-     *      DSpaceConstants is a singleton service with constants.
+     *      DSpaceConstantsService is a singleton service with constants.
      */
-    constructor(private dspaceConstants: DSpaceConstants) {
+    constructor(private dspaceConstants: DSpaceConstantsService) {
         this.itemPages = new Map<number, any>();
         this.collectionPages = new Map<number, any>();
         this.communityPages = new Map<number, any>();
@@ -53,7 +53,7 @@ export class PagingStoreService {
     }
 
     /**
-     * Method to add context page to the store. 
+     * Method to add context page to the store.
      *
      * @param type
      *      community, collection, or item
@@ -70,7 +70,7 @@ export class PagingStoreService {
     }
 
     /**
-     * Method to clear pages by type and id. 
+     * Method to clear pages by type and id.
      *
      * @param context
      *      context: community, collection, or item

--- a/src/app/main.ts
+++ b/src/app/main.ts
@@ -22,8 +22,8 @@ import { AppComponent } from './app.component';
 import { AuthorizationService } from './dspace/authorization/services/authorization.service';
 import { BreadcrumbService } from './navigation/services/breadcrumb.service';
 import { ContextProviderService } from './dspace/services/context-provider.service';
-import { DSpaceConstants } from './dspace/dspace.constants';
-import { DSpaceDirectory } from './dspace/dspace.directory';
+import { DSpaceConstantsService } from './dspace/services/dspace-constants.service';
+import { DSpaceHierarchyService } from './dspace/services/dspace-hierarchy.service';
 import { DSpaceService } from './dspace/services/dspace.service';
 import { FormService } from './utilities/form/form.service';
 import { GoogleScholarMetadataService } from './utilities/services/google-scholar-metadata.service.ts';
@@ -58,8 +58,8 @@ bootstrap(AppComponent, [
     AuthorizationService,
     BreadcrumbService,
     ContextProviderService,
-    DSpaceConstants,
-    DSpaceDirectory,
+    DSpaceConstantsService,
+    DSpaceHierarchyService,
     DSpaceService,
     FormService,
     GoogleScholarMetadataService,

--- a/src/app/navigation/components/breadcrumb.component.ts
+++ b/src/app/navigation/components/breadcrumb.component.ts
@@ -1,11 +1,11 @@
 import { Component, AfterViewInit, OnDestroy } from '@angular/core';
 import { ROUTER_DIRECTIVES } from '@angular/router-deprecated';
 
-import { DSpaceDirectory } from '../../dspace/dspace.directory';
+import { DSpaceHierarchyService } from '../../dspace/services/dspace-hierarchy.service';
 import { BreadcrumbService } from '../services/breadcrumb.service';
 
 /**
- * Breadcrumb component for displaying current set of breadcrumbs of the 
+ * Breadcrumb component for displaying current set of breadcrumbs of the
  * hierarchy to the given context. e.g. Dashboard / Community / Collection / Item
  */
 @Component({
@@ -39,11 +39,11 @@ export class BreadcrumbComponent implements AfterViewInit, OnDestroy {
     /**
      *
      * @param dspace
-     *      DSpaceDirectory is a singleton service to interact with the dspace directory.
+     *      DSpaceHierarchyService is a singleton service to interact with the dspace hierarchy.
      * @param breadcrumbService
      *      BreadcrumbService is a singleton service to interact with the breadcrumb component.
      */
-    constructor(private dspace: DSpaceDirectory,
+    constructor(private dspace: DSpaceHierarchyService,
                 private breadcrumbService: BreadcrumbService) {
 
     }
@@ -71,7 +71,7 @@ export class BreadcrumbComponent implements AfterViewInit, OnDestroy {
 
     /**
      * Method to build the breadcrumb trail when a given context is visited.
-     * 
+     *
      * @param context
      *      The current context. Represents a dspace object community, collection, or item.
      */
@@ -108,7 +108,7 @@ export class BreadcrumbComponent implements AfterViewInit, OnDestroy {
      */
     private dropBreadcrumb(context): Promise<any> {
         let bc = this;
-        return new Promise(function (resolve, reject) { 
+        return new Promise(function (resolve, reject) {
             bc.trail.unshift({
                 name: context.name,
                 type: context.type,
@@ -116,7 +116,7 @@ export class BreadcrumbComponent implements AfterViewInit, OnDestroy {
                 id: context.id,
                 page: context.page,
                 limit: context.limit
-            });            
+            });
             if ((context.parentCommunity && context.parentCommunity.type) || (context.parentCollection && context.parentCollection.type)) {
                 let parentType = context.parentCommunity ? 'Community' : 'Collection';
                 if (context['parent' + parentType].ready) {

--- a/src/app/navigation/components/pagination.component.ts
+++ b/src/app/navigation/components/pagination.component.ts
@@ -2,7 +2,7 @@ import { Component, Input, OnInit } from '@angular/core';
 import { ROUTER_DIRECTIVES, Router } from '@angular/router-deprecated';
 
 import { BreadcrumbService } from '../services/breadcrumb.service';
-import { DSpaceDirectory } from '../../dspace/dspace.directory';
+import { DSpaceHierarchyService } from '../../dspace/services/dspace-hierarchy.service';
 import { PagingStoreService } from '../../dspace/services/paging-store.service';
 import { PaginationService } from '../services/pagination.service';
 
@@ -52,21 +52,21 @@ export class PaginationComponent implements OnInit {
      * A number that represents the previous page.
      */
     private previous: number;
-    
+
     /**
      * A number that represents the next page.
      */
     private next: number;
-    
+
      /**
      * A number array that represents options for a context pagination limit.
      */
     private limitOptions: Array<number>;
-    
+
     /**
-     * 
+     *
      * @param dspace
-     *      DSpaceDirectory is a singleton service to interact with the dspace directory.
+     *      DSpaceHierarchyService is a singleton service to interact with the dspace hierarchy.
      * @param pagingStore
      *      PagingStoreService is a singleton service to cache context which have already been requested.
      * @param paginationService
@@ -76,12 +76,12 @@ export class PaginationComponent implements OnInit {
      * @param router
      *      Router is a singleton service provided by Angular2.
      */
-    constructor(private dspace: DSpaceDirectory,
+    constructor(private dspace: DSpaceHierarchyService,
                 private pagingStore: PagingStoreService,
                 private paginationService: PaginationService,
                 private breadcrumbService: BreadcrumbService,
                 private router: Router) {
-        this.limitOptions = paginationService.getLimitOptions();    
+        this.limitOptions = paginationService.getLimitOptions();
     }
 
      /**
@@ -101,7 +101,7 @@ export class PaginationComponent implements OnInit {
 
     /**
      * Method to page on the dashboard. Does not navigate, only requests next page.
-     * 
+     *
      * @param page
      *          The page being navigated to.
      */

--- a/src/app/navigation/components/tree.component.ts
+++ b/src/app/navigation/components/tree.component.ts
@@ -5,10 +5,10 @@ import { ListComponent } from './list.component';
 import { PaginationComponent } from './pagination.component';
 
 /**
- * Tree component for navigation through the dspace index of 
+ * Tree component for navigation through the dspace index of
  * communities, collections, and items. Keys off an enhanced property
  * on the given context named expanded. Displays +/- glyphicon for communities
- * and a open/closed folder for collections. The title of the given context is 
+ * and a open/closed folder for collections. The title of the given context is
  * a link.
  */
 @Component({
@@ -19,24 +19,24 @@ import { PaginationComponent } from './pagination.component';
                   PaginationComponent ],
     template: `
                 <ul class="list-group">
-                    <li *ngFor="let directory of directories" class="list-group-item">
-                        <span *ngIf="collapsedCommunity(directory)" (click)="directory.toggle()" class="glyphicon glyphicon-plus clickable"></span>
-                        <span *ngIf="expandedCommunity(directory)" (click)="directory.toggle()" class="glyphicon glyphicon-minus clickable"></span>
-                        <span *ngIf="collapsedCollection(directory)" (click)="directory.toggle()" class="glyphicon glyphicon-folder-close clickable"></span>
-                        <span *ngIf="expandedCollection(directory)" (click)="directory.toggle()" class="glyphicon glyphicon-folder-open clickable"></span>
+                    <li *ngFor="let hierarchy of hierarchies" class="list-group-item">
+                        <span *ngIf="collapsedCommunity(hierarchy)" (click)="hierarchy.toggle()" class="glyphicon glyphicon-plus clickable"></span>
+                        <span *ngIf="expandedCommunity(hierarchy)" (click)="hierarchy.toggle()" class="glyphicon glyphicon-minus clickable"></span>
+                        <span *ngIf="collapsedCollection(hierarchy)" (click)="hierarchy.toggle()" class="glyphicon glyphicon-folder-close clickable"></span>
+                        <span *ngIf="expandedCollection(hierarchy)" (click)="hierarchy.toggle()" class="glyphicon glyphicon-folder-open clickable"></span>
 
                         <!-- Router link -->
-                        <a *ngIf="!page(directory)" [routerLink]="[directory.component, {id:directory.id}]">{{ directory.name }}</a>
-                        <a *ngIf="pageWithoutLimit(directory)" [routerLink]="[directory.component, {id:directory.id, page: directory.page}]">{{ directory.name }}</a>
-                        <a *ngIf="pageWithLimit(directory)" [routerLink]="[directory.component, {id:directory.id, page: directory.page, limit: directory.limit}]">{{ directory.name }}</a>
+                        <a *ngIf="!page(hierarchy)" [routerLink]="[hierarchy.component, {id:hierarchy.id}]">{{ hierarchy.name }}</a>
+                        <a *ngIf="pageWithoutLimit(hierarchy)" [routerLink]="[hierarchy.component, {id:hierarchy.id, page: hierarchy.page}]">{{ hierarchy.name }}</a>
+                        <a *ngIf="pageWithLimit(hierarchy)" [routerLink]="[hierarchy.component, {id:hierarchy.id, page: hierarchy.page, limit: hierarchy.limit}]">{{ hierarchy.name }}</a>
 
-                        <span *ngIf="community(directory)" class="badge">{{ directory.countItems }}</span>
-                        <span *ngIf="collection(directory)" class="badge">{{ directory.numberItems }}</span>
-                        <div *ngIf="expandedCommunity(directory)">
-                            <tree [directories]="subCommunitiesAndCollections(directory)"></tree>
+                        <span *ngIf="community(hierarchy)" class="badge">{{ hierarchy.countItems }}</span>
+                        <span *ngIf="collection(hierarchy)" class="badge">{{ hierarchy.numberItems }}</span>
+                        <div *ngIf="expandedCommunity(hierarchy)">
+                            <tree [hierarchies]="subCommunitiesAndCollections(hierarchy)"></tree>
                         </div>
-                        <div *ngIf="expandedCollectionWithItems(directory)">
-                            <list [collection]="directory"></list>
+                        <div *ngIf="expandedCollectionWithItems(hierarchy)">
+                            <list [collection]="hierarchy"></list>
                         </div>
                     </li>
                 </ul>
@@ -45,88 +45,88 @@ import { PaginationComponent } from './pagination.component';
 export class TreeComponent {
 
     /**
-     * An input variable that is passed into the component [directories]. 
-     * Represents the current level of the index hierarchy. The children navigation 
+     * An input variable that is passed into the component [hierarchies].
+     * Represents the current level(s) of the index hierarchy. The children navigation
      * is loaded upon selecting a given context. The subsequent children navigation
      * are lazy loaded.
      */
-    @Input() private directories: Array<any>;
-    
+    @Input() private hierarchies: Array<any>;
+
     /**
      *
      */
-    private subCommunitiesAndCollections(directory: any): Array<any> {
-        return directory.subcommunities.concat(directory.collections);
+    private subCommunitiesAndCollections(hierarchy: any): Array<any> {
+        return hierarchy.subcommunities.concat(hierarchy.collections);
     }
 
     /**
      *
      */
-    private collapsedCommunity(directory: any): boolean {
-        return this.community(directory) && !directory.expanded;
+    private collapsedCommunity(hierarchy: any): boolean {
+        return this.community(hierarchy) && !hierarchy.expanded;
     }
 
     /**
      *
      */
-    private expandedCommunity(directory: any): boolean {
-        return this.community(directory) && directory.expanded;
+    private expandedCommunity(hierarchy: any): boolean {
+        return this.community(hierarchy) && hierarchy.expanded;
     }
 
     /**
      *
      */
-    private collapsedCollection(directory: any): boolean {
-        return this.collection(directory) && !directory.expanded;
+    private collapsedCollection(hierarchy: any): boolean {
+        return this.collection(hierarchy) && !hierarchy.expanded;
     }
 
     /**
      *
      */
-    private expandedCollection(directory: any): boolean {
-        return this.collection(directory) && directory.expanded;
+    private expandedCollection(hierarchy: any): boolean {
+        return this.collection(hierarchy) && hierarchy.expanded;
     }
 
     /**
      *
      */
-    private expandedCollectionWithItems(directory: any): boolean {
-        return this.expandedCollection(directory) && directory.items.length > 0;
+    private expandedCollectionWithItems(hierarchy: any): boolean {
+        return this.expandedCollection(hierarchy) && hierarchy.items.length > 0;
     }
 
     /**
      *
      */
-    private community(directory: any): boolean {
-        return directory.type == 'community';
+    private community(hierarchy: any): boolean {
+        return hierarchy.type == 'community';
     }
 
     /**
      *
      */
-    private collection(directory: any): boolean {
-        return directory.type == 'collection';
+    private collection(hierarchy: any): boolean {
+        return hierarchy.type == 'collection';
     }
 
     /**
      *
      */
-    private page(directory: any): boolean {
-        return directory.page ? true : false;
+    private page(hierarchy: any): boolean {
+        return hierarchy.page ? true : false;
     }
 
     /**
      *
      */
-    private pageWithoutLimit(directory: any): boolean {
-        return this.page(directory) && !directory.limit;
+    private pageWithoutLimit(hierarchy: any): boolean {
+        return this.page(hierarchy) && !hierarchy.limit;
     }
 
     /**
      *
      */
-    private pageWithLimit(directory: any): boolean {
-        return this.page(directory) && directory.limit;
+    private pageWithLimit(hierarchy: any): boolean {
+        return this.page(hierarchy) && hierarchy.limit;
     }
 
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -34,8 +34,8 @@ import { TitleComponent } from './server/title.component';
 import { AuthorizationService } from './app/dspace/authorization/services/authorization.service';
 import { BreadcrumbService } from './app/navigation/services/breadcrumb.service';
 import { ContextProviderService } from './app/dspace/services/context-provider.service';
-import { DSpaceConstants } from './app/dspace/dspace.constants';
-import { DSpaceDirectory } from './app/dspace/dspace.directory';
+import { DSpaceConstantsService } from './app/dspace/services/dspace-constants.service';
+import { DSpaceHierarchyService } from './app/dspace/services/dspace-hierarchy.service';
 import { DSpaceService } from './app/dspace/services/dspace.service';
 import { FormService } from './app/utilities/form/form.service';
 import { GoogleScholarMetadataService } from './app/utilities/services/google-scholar-metadata.service.ts';
@@ -125,8 +125,8 @@ function ngApp(req, res) {
             AuthorizationService,
             BreadcrumbService,
             ContextProviderService,
-            DSpaceConstants,
-            DSpaceDirectory,
+            DSpaceConstantsService,
+            DSpaceHierarchyService,
             DSpaceService,
             FormService,
             GoogleScholarMetadataService,


### PR DESCRIPTION
Fix for #114.

This PR changes the following:
- `DSpaceDirectory` is now `DSpaceHierarchyService`. I chose "hierarchy" cause it fit better in terms of all the other code refactors.
- Refactored all code that referred to `directory` or `directories` to now refer to `hierarchy` or `hierarchies`
- `DSpaceConstants` is now `DSpaceConstantsService`. Refactored code for that.

This PR doesn't add any new features, it's just a code rename/refactor. I've run some tests on my end and everything seems to work fine.
