### PR TITLE
Speed increase on first load

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "angular2-universal": "0.101.3",
     "body-parser": "1.15.1",
     "bootstrap": "3.3.6",
+    "compression": "^1.6.2",
     "express": "4.13.4",
     "ng2-bootstrap": "^1.0.16",
     "ng2-translate": "2.1.0",

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,6 +1,7 @@
 import * as path from 'path';
 import * as express from 'express';
 import * as bodyParser from 'body-parser';
+import * as compression from 'compression';
 
 import 'angular2-universal/polyfills';
 
@@ -61,6 +62,16 @@ let app = express();
 // Root directory of our app is the top level directory (i.e. [src])
 let root = path.join(path.resolve(__dirname, '..'));
 
+// Enable compression of all compressible formats
+// This speeds up initial download of CSS, HTML, JS files, etc.
+app.use(compression());
+
+// Define location of Static Resources
+// Map the /static URL path to the ./dist/server/static local directory
+app.use('/static', express.static(path.join(root, 'dist', 'server', 'static'), {index:false}));
+// Other static resources (e.g. our compiled app.bundle.js) can be found directly in ./dist
+app.use(express.static(path.join(root, 'dist'), {index:false}));
+
 // Create an express "middleware" function which embeds CORS headers (http://enable-cors.org/)
 // into any response we receive.
 // TODO: Once DSpace's REST API returns CORS headers, this can be removed.
@@ -86,13 +97,8 @@ app.engine('.html', expressEngine);
 app.set('views', __dirname + '/app/view');
 app.set('view engine', 'html');
 
+// Enable parsing application/json content
 app.use(bodyParser.json());
-
-// Define location of Static Resources
-// Map the /static URL path to the ./dist/server/static local directory
-app.use('/static', express.static(path.join(root, 'dist', 'server', 'static'), {index:false}));
-// Other static resources (e.g. our compiled app.bundle.js) can be found directly in ./dist
-app.use(express.static(path.join(root, 'dist'), {index:false}));
 
 // Port to use
 app.set('port', PORT);

--- a/typings.json
+++ b/typings.json
@@ -1,6 +1,7 @@
 {
   "ambientDependencies": {
     "body-parser": "registry:dt/body-parser#0.0.0+20160317120654",
+    "compression": "registry:dt/compression#0.0.0+20160501162003",
     "es6-shim": "registry:dt/es6-shim#0.31.2+20160317120654",
     "express": "registry:dt/express#4.0.0+20160317120654",
     "express-serve-static-core": "registry:dt/express-serve-static-core#0.0.0+20160322035842",


### PR DESCRIPTION
- Enable compression of CSS/JS/HTML files
- Load static content into express server FIRST (See http://stackoverflow.com/questions/26106399/node-js-express-js-very-slow-serving-static-files)

With these changes in place, our app size decreases from ~3.8MB to 701KB.  For me, using Chrome's DevTools with Throttling (at Regular 3G speeds and no caching) the initial download time decreases from ~43 seconds to ~9 seconds.

This may help to solve #79
