### PR TITLE
Fixes #118 : Drag and drop multi-uploads

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "compression": "^1.6.2",
     "express": "4.13.4",
     "ng2-bootstrap": "^1.0.16",
+    "ng2-file-upload": "^1.0.3",
     "ng2-translate": "2.1.0",
     "object-hash": "1.1.2",
     "preboot": "2.1.2",

--- a/resources/css/styles.css
+++ b/resources/css/styles.css
@@ -159,6 +159,13 @@ html, body {
     color: #337ab7;
 }
 
+/** File Upload theming **/
+.file-drop-zone {
+    border: dotted 3px lightgray;
+}
+.file-over-drop-zone {
+    border: dotted 3px red;
+}
 
 /* bootstrap overrides */
 

--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -105,6 +105,7 @@
     "item.file-upload.queue.size": "Size",
     "item.file-upload.queue.description": "Description (optional)",
     "item.file-upload.queue.remove": "Remove",
+    "item.file-upload.queue.progress": "Uploading {{count}} files",
 
     "item-view.full.full-bitstreams.title": "Files in this item",
     "item-view.full.full-bitstreams.description.name": "name:",

--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -49,6 +49,8 @@
     "item.language": "Language",
     "item.metadata-number-indicator": "#",
 
+    "item.metadata.header": "Specify Metadata",
+
     "item.metadata.dc.contributor.author.required": "Author is required.",
     "item.metadata.dc.contributor.author.minLength": "Author must have at least 4 characters.",
     "item.metadata.dc.contributor.author.maxLength": "Author must have at most 128 characters.",
@@ -88,9 +90,21 @@
     "item.metadata.dc.type.minLength": "Type must have at least 3 characters.",
     "item.metadata.dc.type.maxLength": "Type must have at most 128 characters.",
 
+    "item.create.header": "Create Item",
+    "item.create.type-select": "Select Type",
+    "item.create.reset-button": "Reset",
+    "item.create.submit-button": "Submit",
     "item.create.processing": "Item {{name}} is being created. Please wait.",
     "item.create.success": "Item {{name}} was created successfully.",
     "item.create.error": "Error creating Item {{name}}.",
+
+    "item.file-upload.header": "Upload file(s)",
+    "item.file-upload.select": "Choose file(s)",
+    "item.file-upload.drop": "OR Drop file(s) here",
+    "item.file-upload.queue.selected": "Selected Files ({{count}})",
+    "item.file-upload.queue.size": "Size",
+    "item.file-upload.queue.description": "Description (optional)",
+    "item.file-upload.queue.remove": "Remove",
 
     "item-view.full.full-bitstreams.title": "Files in this item",
     "item-view.full.full-bitstreams.description.name": "name:",

--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -106,6 +106,8 @@
     "item.file-upload.queue.description": "Description (optional)",
     "item.file-upload.queue.remove": "Remove",
     "item.file-upload.queue.progress": "Uploading {{count}} files",
+    "item.file-upload.queue.error": "File {{name}} could not be added to queue!",
+    "item.file-upload.upload.error": "File {{name}} could not be uploaded!",
 
     "item-view.full.full-bitstreams.title": "Files in this item",
     "item-view.full.full-bitstreams.description.name": "name:",

--- a/src/app/dspace/components/item-bitstream-add.component.ts
+++ b/src/app/dspace/components/item-bitstream-add.component.ts
@@ -1,6 +1,8 @@
 import { Component, Input } from '@angular/core';
 import { CORE_DIRECTIVES, FORM_DIRECTIVES, NgClass, NgStyle } from '@angular/common';
+
 import { FILE_UPLOAD_DIRECTIVES, FileUploader } from 'ng2-file-upload/ng2-file-upload';
+import { TranslatePipe } from "ng2-translate/ng2-translate";
 
 /**
  * Component which provides the ability to add bitstreams to a queue to be uploaded.
@@ -8,6 +10,7 @@ import { FILE_UPLOAD_DIRECTIVES, FileUploader } from 'ng2-file-upload/ng2-file-u
  */
 @Component({
     selector: 'item-bitstream-add',
+    pipes: [ TranslatePipe ],
     directives: [ CORE_DIRECTIVES,
                   FORM_DIRECTIVES,
                   FILE_UPLOAD_DIRECTIVES,
@@ -15,7 +18,7 @@ import { FILE_UPLOAD_DIRECTIVES, FileUploader } from 'ng2-file-upload/ng2-file-u
                   NgStyle ],
     template: `
                 <hr>
-                <label for="file-upload">Upload File(s)</label>
+                <h4><label for="file-upload">{{ 'item.file-upload.header' | translate }}</label></h4>
                 <div class="row">
                     <div class="col-md-12 col-xs-10">
                         <div ng2FileDrop
@@ -24,9 +27,9 @@ import { FILE_UPLOAD_DIRECTIVES, FileUploader } from 'ng2-file-upload/ng2-file-u
                             [uploader]="uploader"
                             class="well file-drop-zone">
                             <span class="btn btn-primary btn-file">
-                                Choose file(s) <input id="file_upload" type="file" ng2FileSelect [uploader]="uploader" multiple  />
+                                {{ 'item.file-upload.select' | translate }} <input id="file_upload" type="file" ng2FileSelect [uploader]="uploader" multiple  />
                             </span>
-                            OR Drop files here
+                            {{ 'item.file-upload.drop' | translate }}
                         </div>
 
                     </div>
@@ -35,10 +38,11 @@ import { FILE_UPLOAD_DIRECTIVES, FileUploader } from 'ng2-file-upload/ng2-file-u
                     <table class="table table-striped" *ngIf="uploader.queue.length > 0">
                         <thead>
                             <tr>
-                                <td><label>Selected Files ({{uploader.queue.length}})</label></td>
-                                <td><label>Size</label></td>
-                                <td><label>Description (optional)</label></td>
-                                <td><label>Remove</label></td>
+                                <!--<td><label>Selected Files ({{uploader.queue.length}})</label></td>-->
+                                <td><label>{{ 'item.file-upload.queue.selected' | translate:{count: uploader.queue.length} }}</label></td>
+                                <td><label>{{ 'item.file-upload.queue.size' | translate}}</label></td>
+                                <td><label>{{ 'item.file-upload.queue.description' | translate}}</label></td>
+                                <td><label>{{ 'item.file-upload.queue.remove' | translate}}</label></td>
                             </tr>
                         </thead>
                         <tbody>

--- a/src/app/dspace/components/item-bitstream-add.component.ts
+++ b/src/app/dspace/components/item-bitstream-add.component.ts
@@ -50,14 +50,14 @@ import { TranslatePipe } from "ng2-translate/ng2-translate";
                                 <td class="col-md-3 col-xs-2">
                                     <label class="space-top">{{ item.file.name }}</label>
                                 </td>
-                                <td class="col-md-3 col-xs-2">
+                                <td class="col-md-2 col-xs-1">
                                     <label class="space-top">{{ item.file.size }}</label>
                                 </td>
                                 <!-- TODO: This is a slight 'hack'. We want to allow defining a description for files.
                                      In this situation, we'll use the 'alias' field of the ng2-file-upload Item to store the description. -->
-                                <td class="col-md-5 col-xs-4">
+                                <td class="col-md-6 col-xs-5">
                                     <input class="form-control" type="text" id="{{ item?.file?.name }}" [(ngModel)]="item.alias">
-                                </td>-
+                                </td>
                                 <td class="col-xs-1 text-center">
                                     <span class="glyphicon glyphicon-remove clickable space-top" aria-hidden="true" (click)="item.remove()"></span>
                                 </td>

--- a/src/app/dspace/components/item-bitstream-add.component.ts
+++ b/src/app/dspace/components/item-bitstream-add.component.ts
@@ -1,80 +1,82 @@
-import {
-    Component,
-    EventEmitter,
-    Input,
-    Output
-} from '@angular/core';
+import { Component, Input } from '@angular/core';
+import { CORE_DIRECTIVES, FORM_DIRECTIVES, NgClass, NgStyle } from '@angular/common';
+import { FILE_UPLOAD_DIRECTIVES, FileUploader } from 'ng2-file-upload/ng2-file-upload';
 
 /**
- *
+ * Component which provides the ability to add bitstreams to a queue to be uploaded.
+ * This component uses ng2-file-upload: https://github.com/valor-software/ng2-file-upload/
  */
 @Component({
     selector: 'item-bitstream-add',
+    directives: [ CORE_DIRECTIVES,
+                  FORM_DIRECTIVES,
+                  FILE_UPLOAD_DIRECTIVES,
+                  NgClass,
+                  NgStyle ],
     template: `
                 <hr>
-                <label for="file-upload">Files</label>
+                <label for="file-upload">Upload File(s)</label>
                 <div class="row">
-                    <div class="col-md-11 col-xs-10">
-                        <span class="btn btn-primary btn-file">
-                            Add File <input id="file-upload" type="file" (change)="addBitstream($event)"/>
-                        </span>
+                    <div class="col-md-12 col-xs-10">
+                        <div ng2FileDrop
+                            [ngClass]="{'file-over-drop-zone': fileOverDropzone}"
+                            (fileOver)="fileOver($event)"
+                            [uploader]="uploader"
+                            class="well file-drop-zone">
+                            <span class="btn btn-primary btn-file">
+                                Choose file(s) <input id="file_upload" type="file" ng2FileSelect [uploader]="uploader" multiple  />
+                            </span>
+                            OR Drop files here
+                        </div>
+
                     </div>
                 </div>
                 <fieldset class="form-group">
-                    <table class="table table-striped" *ngIf="files.length > 0">
+                    <table class="table table-striped" *ngIf="uploader.queue.length > 0">
                         <thead>
                             <tr>
-                                <td><label>File</label></td>
-                                <td><label>Description</label></td>
+                                <td><label>Selected Files ({{uploader.queue.length}})</label></td>
+                                <td><label>Size</label></td>
+                                <td><label>Description (optional)</label></td>
                                 <td><label>Remove</label></td>
                             </tr>
                         </thead>
                         <tbody>
-                            <tr *ngFor="let file of files">
+                            <tr *ngFor="let item of uploader.queue">
                                 <td class="col-md-3 col-xs-2">
-                                    <label class="space-top">{{ file.name }}</label>
+                                    <label class="space-top">{{ item.file.name }}</label>
                                 </td>
-                                <td class="col-md-9 col-xs-8">
-                                    <input class="form-control" type="text" id="{{ file.name }}" [(ngModel)]="file.description">
+                                <td class="col-md-3 col-xs-2">
+                                    <label class="space-top">{{ item.file.size }}</label>
                                 </td>
+                                <!-- TODO: This is a slight 'hack'. We want to allow defining a description for files.
+                                     In this situation, we'll use the 'alias' field of the ng2-file-upload Item to store the description. -->
+                                <td class="col-md-5 col-xs-4">
+                                    <input class="form-control" type="text" id="{{ item?.file?.name }}" [(ngModel)]="item.alias">
+                                </td>-
                                 <td class="col-xs-1 text-center">
-                                    <span class="glyphicon glyphicon-remove clickable space-top" aria-hidden="true" (click)="removeBitstream(file)"></span>
+                                    <span class="glyphicon glyphicon-remove clickable space-top" aria-hidden="true" (click)="item.remove()"></span>
                                 </td>
                             </tr>
                         </tbody>
                     </table>
                 </fieldset>
-              `
+            `
 })
 export class ItemBitstreamAddComponent {
 
     /**
-     * Bitstreams.
+     * FileUploader is passed in from the parent component
      */
-    @Input("files") private files: Array<any>;
+    @Input("uploader") private uploader: FileUploader;
+
+    // Whether a file is hovering over a dropzone (for drag and drop)
+    public fileOverDropzone:boolean = false;
 
     /**
-     *
+     * If file is over the drop zone, change flag. This lets us change the styles dynamically.
      */
-    @Output('addBitstreamEmitter') addBitstreamEmitter: EventEmitter<any> = new EventEmitter<any>();
-
-    /**
-     *
-     */
-    @Output('removeBitstreamEmitter') removeBitstreamEmitter: EventEmitter<any> = new EventEmitter<any>();
-
-    /**
-     *
-     */
-    private addBitstream(event: any): void {
-        this.addBitstreamEmitter.next(event);
+    public fileOver(e:any):void {
+        this.fileOverDropzone = e;
     }
-
-    /**
-     *
-     */
-    private removeBitstream(file: any): void {
-        this.removeBitstreamEmitter.next(file);
-    }
-
 }

--- a/src/app/dspace/components/item-create.component.ts
+++ b/src/app/dspace/components/item-create.component.ts
@@ -12,7 +12,7 @@ import {
 
 import { Observable } from 'rxjs/Rx';
 
-import { TranslateService } from "ng2-translate/ng2-translate";
+import { TranslateService, TranslatePipe } from "ng2-translate/ng2-translate";
 
 import { AuthorizationService } from '../authorization/services/authorization.service';
 import { ContextProviderService } from '../services/context-provider.service';
@@ -39,12 +39,13 @@ import { BitstreamUploader } from '../services/bitstream-uploader.service';
 @Component({
     selector: 'item-create',
     bindings: [ FORM_BINDINGS ],
+    pipes: [ TranslatePipe ],
     directives: [ FORM_DIRECTIVES,
                   LoaderComponent,
                   ItemBitstreamAddComponent,
                   ItemMetadataInputComponent ],
     template: `
-                <h3>Create Item</h3>
+                <h1>{{ 'item.create.header' | translate }}</h1>
                 <loader *ngIf="processing" [message]="processingMessage()"></loader>
 
                 <!-- Display the form -->
@@ -52,10 +53,9 @@ import { BitstreamUploader } from '../services/bitstream-uploader.service';
                     <!-- Add bitstreams/files -->
                     <item-bitstream-add [uploader]="uploader"></item-bitstream-add>
 
-
                     <!-- As long as the default form has a Type input field, we'll display it first -->
                     <!-- Select to change form to a given type, which loads a new type-based form -->
-                    <label *ngIf="hasTypeInput()" for="type">Select Type</label>
+                    <h4><label *ngIf="hasTypeInput()" for="type">{{ 'item.create.type-select' | translate }}</label></h4>
                     <select *ngIf="hasTypeInput()" class="form-control" id="type" [(ngModel)]="selected" (ngModelChange)="typeSelected($event)">>
                         <option *ngFor="let option of typeInput.options" [ngValue]="option">{{ option.gloss }}</option>
                     </select>
@@ -67,8 +67,8 @@ import { BitstreamUploader } from '../services/bitstream-uploader.service';
                     </item-metadata-input>
                     <!-- Form buttons -->
                     <div class="pull-right">
-                        <button type="button" class="btn btn-default btn-sm" (click)="reset()">Reset</button>
-                        <button type="submit" class="btn btn-primary btn-sm" [disabled]="disabled()">Submit</button>
+                        <button type="button" class="btn btn-default btn-sm" (click)="reset()">{{ 'item.create.reset-button' | translate }}<</button>
+                        <button type="submit" class="btn btn-primary btn-sm" [disabled]="disabled()">{{ 'item.create.submit-button' | translate }}</button>
                     </div>
                 </form>
               `
@@ -228,34 +228,6 @@ export class ItemCreateComponent extends FormSecureComponent {
         this.router.navigate(['/Collections', { id: currentContext.id }]);
         this.notificationService.notify('app', 'SUCCESS', this.translate.instant('item.create.success', { name: itemName }), 15);
     }
-
-    /**
-     * Add bitstream from item being created.
-     *
-     * @param file
-     *      Agmented file to add to item being created
-     */
-    /*private addBitstream(event: any): void {
-        var files = event.srcElement ? event.srcElement.files : event.target.files;
-        for(let file of files) {
-            this.files.push(file);
-        }
-    }*/
-
-    /**
-     * Remove bitstream from item being created.
-     *
-     * @param file
-     *      Agmented file to remove from item being created
-     */
-    /*private removeBitstream(file: any): void {
-        for(let i = this.files.length - 1; i >= 0; i--) {
-            if(this.files[i].name == file.name) {
-                this.files.splice(i, 1);
-                break;
-            }
-        }
-    }*/
 
     /**
      * Add metadatum input to the current form.

--- a/src/app/dspace/components/item-create.component.ts
+++ b/src/app/dspace/components/item-create.component.ts
@@ -301,20 +301,11 @@ export class ItemCreateComponent extends FormSecureComponent {
                 // If we have files in our upload queue, upload them
                 if (this.uploader.queue.length>0)
                 {
-                    // Save the item and authToken to our custom uploader
-                    // so they can be used in the upload process
-                    this.uploader.item = this.item;
-                    this.uploader.authToken = token;
-
                     // Upload all files
-                    this.uploadAll().subscribe (response => {
+                    this.uploadAll(this.item, token).subscribe (response => {
                         // Finish up the item
                         this.finish(this.item.name, currentContext);
                     });
-
-
-                    // Finish up the item
-                    //this.finish(this.item.name, currentContext);
                 }
                 else {
                     this.finish(this.item.name, currentContext);
@@ -347,8 +338,12 @@ export class ItemCreateComponent extends FormSecureComponent {
     /**
      * Upload all files in queue, returning an Observable which will not complete
      * until all files in queue have been fully uploaded.
+     * @param item
+     *      Item to upload files into
+     * @param token
+     *      Authentication token
      */
-    private uploadAll(): Observable<boolean> {
+    private uploadAll(item: Item, token:string): Observable<boolean> {
         // Return an observer which waits for all uploads to complete
         return Observable.create(observer => {
             // Create a custom FileUploader.onCompleteAll() callback which completes
@@ -357,6 +352,11 @@ export class ItemCreateComponent extends FormSecureComponent {
                 observer.next(true);
                 observer.complete();
             }
+
+            // Save the item and authToken to our custom uploader
+            // so they can be used in the upload process
+            this.uploader.item = item;
+            this.uploader.authToken = token;
 
             // Then, start the upload of all items!
             this.uploader.uploadAll();

--- a/src/app/dspace/components/item-metadata-input.component.ts
+++ b/src/app/dspace/components/item-metadata-input.component.ts
@@ -23,7 +23,7 @@ import { FormInput } from '../../utilities/form/form-input.model';
     directives: [ FORM_DIRECTIVES, FormValidationMessageComponent ],
     template: `
                 <hr>
-                <label>Metadata</label>
+                <label>Specify Metadata</label>
                 <table class="table table-striped">
                     <tbody>
                         <!-- Create a new row per metadata field -->
@@ -78,80 +78,84 @@ export class ItemMetadataInputComponent {
     @Input("metadatumInputs") private metadatumInputs: Array<FormInput>;
 
     /**
-     *
+     * Defines an 'addMetadatumInputEmitter' output directive, which passes
+     * events up to the parent component (so they can be acted upon as needed)
      */
     @Output('addMetadatumInputEmitter') addMetadatumInputEmitter: EventEmitter<FormInput> = new EventEmitter<FormInput>();
 
     /**
-     *
+     * Defines a 'removeMetadatumInputEmitter' output directive, which passes
+     * events up to the parent component (so they can be acted upon as needed)
      */
     @Output('removeMetadatumInputEmitter') removeMetadatumInputEmitter: EventEmitter<FormInput> = new EventEmitter<FormInput>();
 
     /**
-     *
+     * This component doesn't actually add metadum inputs, instead it adds this event
+     * to its output, so that the parent component can be notified to add the input.
      */
     private addMetadatumInput(input: FormInput): void {
         this.addMetadatumInputEmitter.next(input);
     }
 
     /**
-     *
+     * This component doesn't actually remove metadum inputs, instead it adds this event
+     * to its output, so that the parent component can be notified to remove the input.
      */
     private removeMetadatumInput(input: FormInput): void {
         this.removeMetadatumInputEmitter.next(input);
     }
 
     /**
-     *
+     * Return whether a given FormInput is a required fields
      */
     private required(input: FormInput): boolean {
         return input.validation.required && input.validation.required.value;
     }
 
     /**
-     *
+     * Return whether a given FormInput is in an error state
      */
     private hasError(input: FormInput): boolean {
         return !this.form.controls[input.id].valid && !this.form.controls[input.id].pristine;
     }
 
     /**
-     *
+     * Return whether a given FormInput is a checkbox
      */
     private checkboxInput(input: FormInput): boolean {
         return input.type == 'CHECKBOX';
     }
 
     /**
-     *
+     * Return whether a given FormInput is a Textbox
      */
     private textInput(input: FormInput): boolean {
         return input.type == 'TEXT';
     }
 
     /**
-     *
+     * Return whether a given FormInput is a date input
      */
     private dateInput(input: FormInput): boolean {
         return input.type == 'DATE';
     }
 
     /**
-     *
+     * Return whether a given FormInput is a TextArea
      */
     private textAreaInput(input: FormInput): boolean {
         return input.type == 'TEXTAREA';
     }
 
     /**
-     *
+     * Return whether a given FormInput is a selectbox / dropdown
      */
     private selectInput(input: FormInput): boolean {
         return input.type == 'SELECT';
     }
 
     /**
-     *
+     * Return whether a given FormInput accepts multiple values.
      */
     private repeat(input: FormInput): boolean {
       return input.repeat ? true : false;

--- a/src/app/dspace/components/item-metadata-input.component.ts
+++ b/src/app/dspace/components/item-metadata-input.component.ts
@@ -23,7 +23,7 @@ import { FormInput } from '../../utilities/form/form-input.model';
     directives: [ FORM_DIRECTIVES, FormValidationMessageComponent ],
     template: `
                 <hr>
-                <label>Specify Metadata</label>
+                <h4><label>{{ 'item.metadata.header' | translate }}</label></h4>
                 <table class="table table-striped">
                     <tbody>
                         <!-- Create a new row per metadata field -->

--- a/src/app/dspace/services/bitstream-uploader.service.ts
+++ b/src/app/dspace/services/bitstream-uploader.service.ts
@@ -1,0 +1,101 @@
+
+import { DSpaceService } from '../services/dspace.service';
+import { NotificationService } from '../../utilities/notification/notification.service';
+import { Item } from "../models/item.model";
+
+import { TranslateService } from "ng2-translate/ng2-translate";
+import { FileUploader } from 'ng2-file-upload';
+
+/**
+ * A basic bitstream uploader service which extends the default
+ * FileUploader provided by https://github.com/valor-software/ng2-file-upload/
+ * <p>
+ * This service overrides a few key methods to handle uploading of DSpace
+ * bitstreams. See below for more info
+ */
+export class BitstreamUploader extends FileUploader {
+
+    /**
+     * Reference to DSpace Item this bitstream will be uploaded to
+     * This will be set *after* the Item is created, which is why it need to be public
+     */
+    public item: Item;
+
+    /**
+     * Reference to DSpace REST API authentication token.
+     * Required to be set for upload to be authenticated.
+     */
+    public authToken: string;
+
+    /**
+     * Override default constructor to also include key DSpace services
+     * @param translate
+     *      TranslateService
+     * @param dspaceService
+     *      DSpaceService is a singleton service to interact with the dspace service.
+     * @param notificationService
+     *      NotificationService is a singleton service to notify user of alerts.
+     * @param options
+     *      FileUploader options to pass to default FileUploader
+     */
+    constructor(private translate: TranslateService,
+                private dspaceService: DSpaceService,
+                private notificationService: NotificationService,
+                options: any) {
+        super(options);
+    }
+
+   /**
+    * Override onAfterAddingFile callback method. This method is called anytime
+    * a new file is added to the upload queue.
+    */
+    public onAfterAddingFile(fileItem: any) {
+       // By default, each fileItem has an alias set to 'file'.
+       // Clear that value, as we'll use the 'alias' to store our Bitstream file description
+       fileItem.alias = '';
+
+       // Set withCredentials to false (which is default value for XHR)
+       // DSpace REST API currently doesn't support CORS requests with credentials
+       // See also https://developer.mozilla.org/en-US/docs/Web/HTTP/Access_control_CORS#Requests_with_credentials
+       fileItem.withCredentials = false;
+    }
+
+
+    /**
+     * Override onBeforeUploadItem callback method. This method is called before
+     * a specific file is uploaded to the server.
+     *
+     * WARNING: We MUST know the Item we are uploading to!!
+     */
+    public onBeforeUploadItem(fileItem: any) {
+        // We cannot proceed if we don't know the Item or have an authentication token.
+        if(this.item === undefined || this.authToken === undefined) {
+            // cancel upload
+            fileItem.cancel();
+        }
+        else {
+            // Add upload headers to form uploader
+            this.options.headers = this.dspaceService.getFileUploadHeaders(fileItem.file.type, this.authToken);
+
+            // Set the file upload URL based on the fileItem's name and alias (i.e. description)
+            fileItem.url = this.dspaceService.getFileUploadURL(this.item, fileItem.file.name, fileItem.alias);
+        }
+     }
+
+    /**
+     * Override callback method. This method is called if a file cannot be added to the queue
+     * @TODO: use i18n
+     */
+    public onWhenAddingFileFailed(fileItem:any, filter:any, options:any):any {
+        this.notificationService.notify('app', 'DANGER', "File " + fileItem.file.name + " could not be added to queue!");
+    }
+
+    /**
+     * Override callback method. This method is called if a file cannot be uploaded
+     * @TODO: use i18n
+     */
+    public onErrorItem(fileItem:any, response:any, status:any, headers:any):any {
+        this.notificationService.notify('app', 'DANGER', "File " + fileItem.file.name + " could not be uploaded!");
+    }
+
+}

--- a/src/app/dspace/services/bitstream-uploader.service.ts
+++ b/src/app/dspace/services/bitstream-uploader.service.ts
@@ -84,18 +84,16 @@ export class BitstreamUploader extends FileUploader {
 
     /**
      * Override callback method. This method is called if a file cannot be added to the queue
-     * @TODO: use i18n
      */
     public onWhenAddingFileFailed(fileItem:any, filter:any, options:any):any {
-        this.notificationService.notify('app', 'DANGER', "File " + fileItem.file.name + " could not be added to queue!");
+        this.notificationService.notify('app', 'DANGER', this.translate.instant('item.file-upload.queue.error', { name: fileItem.file.name }));
     }
 
     /**
      * Override callback method. This method is called if a file cannot be uploaded
-     * @TODO: use i18n
      */
     public onErrorItem(fileItem:any, response:any, status:any, headers:any):any {
-        this.notificationService.notify('app', 'DANGER', "File " + fileItem.file.name + " could not be uploaded!");
+        this.notificationService.notify('app', 'DANGER', this.translate.instant('item.file-upload.upload.error', { name: fileItem.file.name }));
     }
 
 }

--- a/src/app/dspace/services/dspace.service.ts
+++ b/src/app/dspace/services/dspace.service.ts
@@ -9,7 +9,7 @@ import { Item } from '../models/item.model';
 import { URLHelper } from "../../utilities/url.helper";
 
 /**
- * Injectable service to provide an interface with the DSpace REST API 
+ * Injectable service to provide an interface with the DSpace REST API
  * through the utility http service. The responses here are returned as
  * Observables and the content is mapped to a JSON object.
  *
@@ -23,7 +23,7 @@ import { URLHelper } from "../../utilities/url.helper";
 export class DSpaceService {
 
     /**
-     * @param httpService 
+     * @param httpService
      *      HttpService is a singleton service to provide basic xhr requests.
      */
     constructor(private httpService: HttpService) {}
@@ -93,7 +93,7 @@ export class DSpaceService {
     }
 
     /**
-     * Method to fetch items of a collection for navigation purposes. 
+     * Method to fetch items of a collection for navigation purposes.
      *
      * @param collectionId
      *      The collection id of which its items are to be fetched.
@@ -115,7 +115,7 @@ export class DSpaceService {
     }
 
     /**
-     * Method to fetch details of a community. 
+     * Method to fetch details of a community.
      *
      * @param id
      *      Community id of which to fetch its relationships and other details.
@@ -129,7 +129,7 @@ export class DSpaceService {
     }
 
     /**
-     * Method to fetch details of a collection. 
+     * Method to fetch details of a collection.
      *
      * @param id
      *      Collection id of which to fetch its relationships and other details.
@@ -143,7 +143,7 @@ export class DSpaceService {
     }
 
     /**
-     * Method to fetch details of an item. 
+     * Method to fetch details of an item.
      *
      * @param id
      *      Item id of which to fetch its relationships and other details.
@@ -157,7 +157,7 @@ export class DSpaceService {
     }
 
     /**
-     * Method to login and recieve a token. 
+     * Method to login and recieve a token.
      *
      * @param email
      *      DSpace user email/login
@@ -175,7 +175,7 @@ export class DSpaceService {
     }
 
     /**
-     * Method to get user status. 
+     * Method to get user status.
      *
      * @param token
      *      DSpace user token
@@ -190,7 +190,7 @@ export class DSpaceService {
     }
 
     /**
-     * Method to logout. 
+     * Method to logout.
      *
      * @param token
      *      DSpace user token
@@ -288,6 +288,39 @@ export class DSpaceService {
                 { key: 'rest-dspace-token', value: token }
             ]
         }, file, token);
+    }
+
+    /**
+    * Return any array of HTTP Headers necessary to perform a file upload
+    * via the DSpace REST API.
+    *
+    * @param token
+    *      DSpace user token
+    */
+    getFileUploadHeaders(fileType: string, token: string): Array<any> {
+        return  [
+            { name: 'Content-Type', value: fileType },
+            { name: 'Accept', value: 'application/json' },
+            { name: 'rest-dspace-token', value: token }
+        ];
+    }
+
+    /**
+    * Return full upload URL for a given file to a given item
+    *
+    * @param item
+    *      Item in which to add bitstream
+    * @param fileName
+    *      Name of file to upload
+    * @param fileDescription
+    *      Optional file description for file
+    */
+    getFileUploadURL(item: Item, fileName: string, fileDescription: string): string {
+        // If description passed in, create a description parameter
+        let descriptionParam = fileDescription!=undefined ? '&description=' + fileDescription : '';
+        // Create and return full upload path for this file
+        let path = '/items/' + item.id + '/bitstreams?name=' + fileName + descriptionParam;
+        return URLHelper.relativeToAbsoluteRESTURL(path);
     }
 
 }


### PR DESCRIPTION
This feature uses [`ng2-file-upload`](https://github.com/valor-software/ng2-file-upload/) to create a drag and drop file upload experience.  `ng2-file-upload` manages the upload queue and the upload process.

It replaces our existing file upload button with a drag-and-drop 'zone' or button option. Either can be used to select multiple files at one time.

Also provides an upload progress bar when the Item Create form is submitted, letting users know the status of the file uploads. 

NOTE: There is a known issue in `ng2-file-upload` regarding uploading files to our REST API.  Unfortunately our REST API doesn't yet support multipart forms, and therefore may corrupt some file formats on upload (especially images). See https://github.com/valor-software/ng2-file-upload/issues/223. I've already submitted a proposed fix to `ng2-file-upload`: https://github.com/valor-software/ng2-file-upload/pull/224

However, I have discovered this exact same upload issue exists in our current file upload code (which also uses multipart forms with our REST API).
