### PR TITLE
Sidebar default visibility

### DIFF
--- a/resources/styles/_sidebar.scss
+++ b/resources/styles/_sidebar.scss
@@ -166,7 +166,7 @@ $sidebar-subsection-bg-color: rgba(255,255,255, 0.04);
         padding-left: ($panel-body-padding * 2) - 4px;
         line-height: $line-height-computed;
         background: $sidebar-subsection-bg-color;
-        border-left: 4px solid $sidebar-subsection-bg-color;
+        border-left: 4px solid transparent;
 
         &,
         &:hover,

--- a/resources/styles/_sidebar.scss
+++ b/resources/styles/_sidebar.scss
@@ -93,6 +93,7 @@ $sidebar-subsection-bg-color: rgba(255,255,255, 0.04);
 
     .icon-arrow-down {
         font-size: 12px;
+        line-height: normal;
     }
 }
 

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,4 +1,4 @@
-﻿﻿import { Component, OnInit, Inject, NgZone } from '@angular/core';
+﻿﻿import { Component, OnInit, Inject } from '@angular/core';
 import { ROUTER_DIRECTIVES, RouteConfig, Router } from '@angular/router-deprecated';
 
 import { TranslateService, TranslatePipe } from "ng2-translate/ng2-translate";
@@ -151,8 +151,6 @@ export class AppComponent implements OnInit {
      *      Router is a singleton service provided by Angular2.
      * @param sidebarService
      *      SidebarService is a singleton service that provides access to the content of the sidebar
-     * @param viewportService
-     *      A singleton service that classifies the viewport's width
      * @param sidebarHelper
      *      SidebarHelper is a helper-class to inject the sidebar sections when the user visits this component
      */
@@ -160,7 +158,6 @@ export class AppComponent implements OnInit {
                 private translate:TranslateService,
                 private router:Router,
                 private sidebarService: SidebarService,
-                private viewportService: ViewportService,
                 @Inject(AppSidebarHelper)  private sidebarHelper:AppSidebarHelper) {
         translate.setDefaultLang('en');
         translate.use('en');
@@ -173,6 +170,7 @@ export class AppComponent implements OnInit {
      */
     private initSidebar(): void {
         this.isSidebarAnimating = false;
+        this.isSidebarVisible = this.sidebarService.isSidebarVisible.getValue();
 
         //Subscribe to the visibility observable of the SidebarService to
         //detect when the sidebar should open and close
@@ -195,28 +193,7 @@ export class AppComponent implements OnInit {
             }, 350);
         });
 
-        //if we have info about the viewport
-        //use it to determine the initial state of the sidebar 
-        if (this.viewportService.isSupported) {
-            let isMd = this.viewportService.isMd.getValue();
-            let isLg = this.viewportService.isLg.getValue();
-            this.sidebarService.setSidebarVisibility(isLg || isMd);
-        }
-        else {
-            //otherwise, default to closed.
-            this.sidebarService.setSidebarVisibility(false);
-        }
-
         this.sidebarHelper.populateSidebar();
-
-        this.router.subscribe(() => {
-            // if the route changes on an XS screen (where the sidebar is fullscreen),
-            // and the sidebar is open, close it.
-            if (this.viewportService.isXs.getValue() &&
-                this.sidebarService.isSidebarVisible.getValue()) {
-                this.sidebarService.setSidebarVisibility(false);
-            }
-        });
     }
 
     /**

--- a/src/app/utilities/services/sidebar.service.ts
+++ b/src/app/utilities/services/sidebar.service.ts
@@ -1,10 +1,12 @@
 import { Injectable } from '@angular/core';
+import { Router } from '@angular/router-deprecated';
 import { Subject } from 'rxjs/Subject';
 import { BehaviorSubject } from "rxjs/BehaviorSubject";
 
 import { SidebarSection } from '../../dspace/models/sidebar/sidebar-section.model.ts';
 import { ObjectUtil } from "../../utilities/commons/object.util";
 import { ArrayUtil } from "../../utilities/commons/array.util";
+import { ViewportService } from "./viewport.service";
 
 /**
  * A class for the sidebar service, to remove and add components to the sidebar.
@@ -32,12 +34,35 @@ export class SidebarService
 
 
     /**
-     *
+     * @param viewportService
+     *      A singleton service that classifies the viewport's width
+     * @param router
+     *      Router is a singleton service provided by Angular2.
      */
-    constructor()
+    constructor(private viewportService: ViewportService,
+                private router:Router
+    )
     {
         this.sidebarSubject = new Subject<any>();
-        this.isSidebarVisible = new BehaviorSubject<boolean>(false);
+        this.isSidebarVisible = new BehaviorSubject<boolean>(true);
+
+        //if we have info about the viewport
+        //use it to determine the initial state of the sidebar
+        if (this.viewportService.isSupported) {
+            let isMd = this.viewportService.isMd.getValue();
+            let isLg = this.viewportService.isLg.getValue();
+            this.setSidebarVisibility(isLg || isMd);
+        }
+
+        this.router.subscribe(() => {
+            // if the route changes on an XS screen (where the sidebar is fullscreen),
+            // and the sidebar is open, close it.
+            if (this.viewportService.isXs.getValue() &&
+                this.isSidebarVisible.getValue()) {
+                this.setSidebarVisibility(false);
+            }
+        });
+
     }
 
 


### PR DESCRIPTION
Moved some of the sidebar visibility logic from app component to the sidebar service, and fixed a little alignment issue with the sidebar header.

I also set the sidebar to default to open on the server. That way, you won't see it open on a desktop every time you refresh the page. However that does mean you'll see it close every time you refresh the page on small screens. But with the OR presentation in mind I think this is the better default. 

This PR connects to #74
