### PR TITLE
Edit sidebar fixes

### DIFF
--- a/resources/userdata/sidebar.json
+++ b/resources/userdata/sidebar.json
@@ -1,1 +1,1 @@
-[{"id":"custom-sidebar-section","index":1.0001,"componentName":"Resources","visible":true,"childsections":[{"id":"custom-section-1464864464838","index":1.0001,"componentName":"google","visible":true,"childsections":[],"routes":[],"url":"http://www.google.com"}],"routes":[]}]
+[]

--- a/resources/userdata/sidebar.json
+++ b/resources/userdata/sidebar.json
@@ -1,1 +1,1 @@
-[{"id":"custom-section-1464872918335","index":1.0001,"componentName":"untitled","visible":true,"childsections":[{"id":"custom-section-1464872918335","index":1.0001,"componentName":"untitled","visible":true,"childsections":[],"url":"http://www.google.be","routes":[]}],"routes":[]},{"id":"custom-section-1464872919617","index":1.0001,"componentName":"untitled","visible":true,"childsections":[{"id":"custom-section-1464872919617","index":1.0001,"componentName":"untitled","visible":true,"childsections":[],"url":"http://www.google.be","routes":[]}],"routes":[]}]
+[]

--- a/resources/userdata/sidebar.json
+++ b/resources/userdata/sidebar.json
@@ -1,1 +1,1 @@
-[]
+[{"id":"custom-section-1464872918335","index":1.0001,"componentName":"untitled","visible":true,"childsections":[{"id":"custom-section-1464872918335","index":1.0001,"componentName":"untitled","visible":true,"childsections":[],"url":"http://www.google.be","routes":[]}],"routes":[]},{"id":"custom-section-1464872919617","index":1.0001,"componentName":"untitled","visible":true,"childsections":[{"id":"custom-section-1464872919617","index":1.0001,"componentName":"untitled","visible":true,"childsections":[],"url":"http://www.google.be","routes":[]}],"routes":[]}]

--- a/src/app/dspace/components/sidebar/admin-sidebar.component.ts
+++ b/src/app/dspace/components/sidebar/admin-sidebar.component.ts
@@ -44,6 +44,8 @@ import {  TranslatePipe } from "ng2-translate/ng2-translate";
                            
                             <!-- we only show the 'plus symbol' on the first entry -->
                             <span *ngIf="i==0" class="ion-icon ion-ios-plus-empty clickable" aria-hidden="true" (click)="addChildSectionField(entry)"></span>
+                            <span  *ngIf="i>0" class="ion-icon ion-ios-close-empty clickable" aria-hidden="true" (click)="removeChildSection(entry,i)"></span>
+                     
                         </div>
                         
                         <!-- if there are no children on the current component, we still want to show an add button to add the first child -->

--- a/src/app/dspace/components/sidebar/admin-sidebar.component.ts
+++ b/src/app/dspace/components/sidebar/admin-sidebar.component.ts
@@ -46,10 +46,7 @@ import {  TranslatePipe } from "ng2-translate/ng2-translate";
                             <span *ngIf="i==0" class="ion-icon ion-ios-plus-empty clickable" aria-hidden="true" (click)="addChildSectionField(entry)"></span>
                             <span  *ngIf="i>0" class="ion-icon ion-ios-close-empty clickable" aria-hidden="true" (click)="removeChildSection(entry,i)"></span>
                      
-                        </div>
-                        
-                        <!-- if there are no children on the current component, we still want to show an add button to add the first child -->
-                        <button *ngIf="!hasChildren(entry)" type="button" class="btn btn-primary btn-sm" (click)="addChildSectionField(entry)">{{'sidebar.admin.edit.add-child' | translate}}</button>        
+                        </div>    
                         
                 </div>
             <!-- buttons here -->

--- a/src/app/dspace/components/sidebar/admin-sidebar.component.ts
+++ b/src/app/dspace/components/sidebar/admin-sidebar.component.ts
@@ -114,7 +114,7 @@ export class AdminSidebarComponent implements OnInit, OnDestroy
     {
         // generate a random ID based on the current time in ms.
         // assign this ID to the SidebarSections with a prefix, so we can easily distinguish which sections were added by users.
-        let parentSection = SidebarSection.getBuilder().generateUserID(true).name("untitled").addChild(SidebarSection.getBuilder().name("untitled").generateUserID(true).url("http://www.google.be").build()).build();
+        let parentSection = SidebarSection.getBuilder().generateUserID(true).name("untitled").addChild(SidebarSection.getBuilder().name("untitled").generateUserID(true).url("http://www.google.com").build()).build();
         //this.addChildSectionField(parentSection);
         this.sidebarService.addSection(parentSection);
         this.entries = this.sidebarService.getCustomSections().slice(0);

--- a/src/app/dspace/components/sidebar/admin-sidebar.component.ts
+++ b/src/app/dspace/components/sidebar/admin-sidebar.component.ts
@@ -114,8 +114,8 @@ export class AdminSidebarComponent implements OnInit, OnDestroy
     {
         // generate a random ID based on the current time in ms.
         // assign this ID to the SidebarSections with a prefix, so we can easily distinguish which sections were added by users.
-        let parentSection = SidebarSection.getBuilder().generateUserID(true).name("untitled").build();
-        this.addChildSectionField(parentSection);
+        let parentSection = SidebarSection.getBuilder().generateUserID(true).name("untitled").addChild(SidebarSection.getBuilder().name("untitled").generateUserID(true).url("http://www.google.be").build()).build();
+        //this.addChildSectionField(parentSection);
         this.sidebarService.addSection(parentSection);
         this.entries = this.sidebarService.getCustomSections().slice(0);
     }


### PR DESCRIPTION
Some fixes relating to #125. 

Currently, the sidebar is not saved across sessions unless the "save" button is clicked. I plan on implementing this asap. Currently navigating away does persist the altered sidebar during that same session, but not outside of it. 

After _save_ is clicked, the sidebar is persisted as expected.
