### PR TITLE
set the sidebar with to a fixed 300px for screens larger than xs

### DIFF
--- a/resources/styles/_sidebar.scss
+++ b/resources/styles/_sidebar.scss
@@ -6,6 +6,7 @@ $sidebar-body-border-color: darken($sidebar-background-color, 3%);
 $sidebar-heading-color: $gray-lighter;
 $sidebar-text-color: $gray-light;
 $sidebar-subsection-bg-color: rgba(255,255,255, 0.04);
+$sidebar-width-sm-and-up: 300px;
 
 
 .sidebar {
@@ -19,11 +20,20 @@ $sidebar-subsection-bg-color: rgba(255,255,255, 0.04);
 .sidebar-open-sidebar,
 .sidebar-closed-sidebar {
     position: fixed;
-    @extend  .col-xs-12, .col-sm-4, .col-lg-3
+    @extend  .col-xs-12;
+
+    @media(min-width: $screen-sm-min) {
+        width: $sidebar-width-sm-and-up;
+    }
 }
 
 .sidebar-open-content {
-    @extend .hidden-xs, .col-sm-8, .col-sm-offset-4, .col-lg-9, .col-lg-offset-3
+    @extend .hidden-xs;
+
+
+    @media(min-width: $screen-sm-min) {
+        margin-left: $sidebar-width-sm-and-up;
+    }
 }
 
 .sidebar-closed-content {


### PR DESCRIPTION
Originally the sidebar was sized using the bootstrap grid, which means it would scale with the screen width. A downside was that it could get very wide on large screens. To fix that problem I set the width to a fixed 300px for everything but the smallest category of screens (where it still takes up the entire screen)

This PR connects to #139
